### PR TITLE
#1 開催日が過去のイベントを非表示

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -38,8 +38,16 @@ INSERT INTO events SET name='横モク', start_at='2021/08/23 21:00', end_at='20
 INSERT INTO events SET name='スペモク', start_at='2021/08/24 20:00', end_at='2021/08/24 22:00';
 INSERT INTO events SET name='遊び', start_at='2021/09/22 18:00', end_at='2021/09/22 22:00';
 INSERT INTO events SET name='ハッカソン', start_at='2021/09/03 10:00', end_at='2021/09/03 22:00';
-INSERT INTO events SET name='遊び', start_at='2021/09/06 18:00', end_at='2021/09/06 22:00';
-
+INSERT INTO events SET name='遊び', start_at='2022/09/07 18:00', end_at='2021/09/06 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/08 18:00', end_at='2021/09/06 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/09 18:00', end_at='2021/09/06 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/10 18:00', end_at='2021/09/06 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/11 18:00', end_at='2021/09/06 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/12 18:00', end_at='2021/09/06 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/13 18:00', end_at='2021/09/06 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/14 18:00', end_at='2021/09/06 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/15 18:00', end_at='2021/09/06 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/16 18:00', end_at='2021/09/06 22:00';
 INSERT INTO event_attendance SET event_id=1;
 INSERT INTO event_attendance SET event_id=1;
 INSERT INTO event_attendance SET event_id=1;

--- a/src/index.php
+++ b/src/index.php
@@ -4,10 +4,12 @@ require('dbconnect.php');
 $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id');
 $events = $stmt->fetchAll();
 
-function get_day_of_week ($w) {
+function get_day_of_week($w)
+{
   $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
   return $day_of_week_list["$w"];
 }
+
 ?>
 
 <!DOCTYPE html>
@@ -48,17 +50,23 @@ function get_day_of_week ($w) {
         </div>
       </div>
       -->
+      <!-- 各イベントカード -->
       <div id="events-list">
         <div class="flex justify-between items-center mb-3">
           <h2 class="text-sm font-bold">一覧</h2>
         </div>
-
         <?php foreach ($events as $event) : ?>
           <?php
           $start_date = strtotime($event['start_at']);
           $end_date = strtotime($event['end_at']);
           $day_of_week = get_day_of_week(date("w", $start_date));
+          $today = strtotime("today");
+          // strtotimeで今日の0:00を取得 star_dateがそれより前であれば、continueで処理をスキップ
+          if ($start_date < $today) {
+            continue;
+          };
           ?>
+
           <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
             <div>
               <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>


### PR DESCRIPTION
## 関連イシュー
#1 

### 終了条件

- [x] 開催日が当日、未来のイベントのみ表示されている

## 検証したこと

- [x] 開催日が過去のイベントが非表示になっていること
- [x] 開催日が今日、未来のイベントが表示になっていること（10件のダミーデータで表示確認済み）

## エビデンス
データベースには過去のイベントのデータも入っているが、
<img width="1158" alt="image" src="https://user-images.githubusercontent.com/94669039/189074012-5e7624ef-61a1-4fa9-8ecb-c093a105a3ce.png">

ユーザー画面には開催日が当日、または未来のイベントのみ表示されます
<img width="374" alt="スクリーンショット 2022-09-07 21 37 54" src="https://user-images.githubusercontent.com/86845003/188880231-424ea3fd-19af-4ba9-bb34-d5161154e3a2.png">
