### PR TITLE
[リバート済み] 無視でお願いします！（旧 #14）

### DIFF
--- a/src/api/getModalInfo.php
+++ b/src/api/getModalInfo.php
@@ -1,9 +1,11 @@
 <?php
+session_start();
 require('../dbconnect.php');
 header('Content-Type: application/json; charset=UTF-8');
 
 if (isset($_GET['eventId'])) {
   $eventId = htmlspecialchars($_GET['eventId']);
+  $userId = $_SESSION['user_id'];
   try {
     $stmt = $db->prepare('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.id = ? GROUP BY events.id');
     $stmt->execute(array($eventId));
@@ -18,6 +20,10 @@ if (isset($_GET['eventId'])) {
     elseif ($event['id'] % 3 === 2) $status = 1;
     else $status = 2;
 
+    $stmt = $db->prepare('SELECT user_id, status FROM event_attendance WHERE event_id = ? AND user_id = ?');
+    $stmt->execute(array($eventId, $userId));
+    $participation_status = $stmt->fetch();
+
     $array = [
       'id' => $event['id'],
       'name' => $event['name'],
@@ -28,6 +34,7 @@ if (isset($_GET['eventId'])) {
       'total_participants' => $event['total_participants'],
       'message' => $eventMessage,
       'status' => $status,
+      'participation_status' => $participation_status['status'],
       'deadline' => date("m月d日", strtotime('-3 day', $end_date)),
     ];
     

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -44,10 +44,12 @@ async function openModal(eventId) {
     switch (event.participation_status) {
       case null:
         modalHTML += `
+          <!--
           <div class="text-center mt-6">
             <p class="text-lg font-bold text-yellow-400">未回答</p>
             <p class="text-xs text-yellow-400">期限 ${event.deadline}</p>
           </div>
+          -->
           <div class="flex mt-5">
             <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" name="presence" value="presence" onclick="participateEvent(${eventId})">参加する</button>
             <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" name="absence" value="absence" onclick="nonParticipateEvent(${eventId})">参加しない</button>
@@ -56,9 +58,11 @@ async function openModal(eventId) {
         break;
       case 'presence':
         modalHTML += `
+          <!--
           <div class="text-center mt-10">
             <p class="text-xl font-bold text-green-400">参加</p>
           </div>
+          -->
           <div class="flex mt-5">
             <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" disabled">参加する</button>
             <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" name="absence" value="absence" onclick="nonParticipateEvent(${eventId})">参加しない</button>
@@ -67,9 +71,11 @@ async function openModal(eventId) {
         break;
       case 'absence':
         modalHTML += `
+          <!--
           <div class="text-center mt-10">
             <p class="text-xl font-bold text-gray-300">不参加</p>
           </div>
+          -->
           <div class="flex mt-5">
             <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" name="presence" value="presence" onclick="participateEvent(${eventId})">参加する</button>
             <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" disabled>参加しない</button>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -71,8 +71,8 @@ async function openModal(eventId) {
             <p class="text-xl font-bold text-gray-300">不参加</p>
           </div>
           <div class="flex mt-5">
-            <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" name="presence" value="presence" onclick="participateEvent(${eventId})">参加する</button>
-            <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" disabled>参加しない</button>
+            <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" name="presence" value="presence" onclick="participateEvent(${eventId})">参加する</button>
+            <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" disabled>参加しない</button>
           </div>
         `
         break;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -41,14 +41,12 @@ async function openModal(eventId) {
 
       <p class="text-sm"><span class="text-xl">${event.total_participants}</span>人参加 ></p>
     `
-    switch (0) {
-      case 0:
+    switch (event.participation_status) {
+      case null:
         modalHTML += `
           <div class="text-center mt-6">
-            <!--
             <p class="text-lg font-bold text-yellow-400">未回答</p>
             <p class="text-xs text-yellow-400">期限 ${event.deadline}</p>
-            -->
           </div>
           <div class="flex mt-5">
             <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" name="presence" value="presence" onclick="participateEvent(${eventId})">参加する</button>
@@ -56,17 +54,25 @@ async function openModal(eventId) {
           </div>
         `
         break;
-      case 1:
+      case 'presence':
+        modalHTML += `
+          <div class="text-center mt-10">
+            <p class="text-xl font-bold text-green-400">参加</p>
+          </div>
+          <div class="flex mt-5">
+            <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" disabled">参加する</button>
+            <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" name="absence" value="absence" onclick="nonParticipateEvent(${eventId})">参加しない</button>
+          </div>
+        `
+        break;
+      case 'absence':
         modalHTML += `
           <div class="text-center mt-10">
             <p class="text-xl font-bold text-gray-300">不参加</p>
           </div>
-        `
-        break;
-      case 2:
-        modalHTML += `
-          <div class="text-center mt-10">
-            <p class="text-xl font-bold text-green-400">参加</p>
+          <div class="flex mt-5">
+            <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" name="presence" value="presence" onclick="participateEvent(${eventId})">参加する</button>
+            <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" disabled>参加しない</button>
           </div>
         `
         break;


### PR DESCRIPTION
## 関連イシュー
#14

### 終了条件

- [x] 参加予定の場合はモーダル画面の参加ボタンを非活性、不参加ボタンを活性
- [x] 不参加予定の場合はモーダル画面の参加ボタンを活性、不参加ボタンを非活性

## 検証したこと
- [x] 参加ボタンを押すと参加ボタンを非活性、不参加ボタンを活性（データも登録される）
- [x] 不参加ボタンを押すと参加ボタンを活性、不参加ボタンを非活性（データも登録される）

## エビデンス

イベントの参加するボタンを押すと参加ボタンが非活性になる（画像でどう見せればいいかわからないのですが、javascript でdisabled属性をつけています。ここでの event_id は15でデータも更新されるため status が presence となる。）
<img width="1426" alt="image" src="https://user-images.githubusercontent.com/86785032/188815620-bf717a26-c216-4333-bcaa-cab44c000dee.png">
<img width="759" alt="image" src="https://user-images.githubusercontent.com/86785032/188812637-7b5fe7e5-9555-412a-8d2d-60a88afef574.png">


さらに、ここで不参加ボタンを押すと参加状態が不参加に変わり、不参加ボタンが非活性化される（データも更新されるためstatus が absence となる）
<img width="1430" alt="image" src="https://user-images.githubusercontent.com/86785032/188815694-ab0863e4-c8d0-4542-8c92-87aab70a01c2.png">
<img width="761" alt="image" src="https://user-images.githubusercontent.com/86785032/188812835-77143ae8-f3b2-4185-b60e-288307a73be2.png">



