### PR TITLE
#9 ログイン機能 Issue3 管理者が対応しなくてもパスワード再設定が出来るようにする

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -56,6 +56,8 @@ INSERT INTO event_attendance SET event_id=2, user_id = 1, status="presence";
 INSERT INTO event_attendance SET event_id=2, user_id = 1, status="presence";
 INSERT INTO event_attendance SET event_id=3, user_id = 1, status="presence";
 
+
+-- ユーザーログイン
 DROP TABLE IF EXISTS users;
 
 CREATE TABLE users (
@@ -67,3 +69,19 @@ CREATE TABLE users (
 INSERT INTO users (email, password) VALUES ("user@posse.com","pass");
 INSERT INTO users (email, password) VALUES ("user2@posse.com","pass");
 
+
+-- パスワードリセット関連です。
+
+DROP TABLE IF EXISTS user_password_reset;
+
+CREATE TABLE user_password_reset (
+    id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
+    email VARCHAR(255) NOT NULL,
+    pass_token VARCHAR(255) NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO
+    user_password_reset(email, pass_token);
+VALUES
+    ("test@test.com", "test");

--- a/src/auth/login/forget.php
+++ b/src/auth/login/forget.php
@@ -1,0 +1,94 @@
+<?php
+
+session_start();
+require('../../dbconnect.php');
+
+
+$err_msg = "";
+
+
+if (isset($_POST['submit_email'])) {
+  $_SESSION["email"] = $_POST['email'];
+  $email = $_POST['email'];
+
+  $sql = 'SELECT count(*) FROM users WHERE email = ?';
+  $stmt = $db->prepare($sql);
+  $stmt->execute(array($email));
+  $result = $stmt->fetch();
+
+  // result に一つでも値が入っているなら、登録メールアドレスが存在するということ
+  if ($result[0] != 0) {
+
+    $passResetToken = md5(uniqid(rand(), true));
+
+    // DB に email と token を追加
+    $sql = "INSERT INTO user_password_reset(email, pass_token) VALUES(?, ?)";
+    $stmt = $db->prepare($sql);
+    $stmt->execute(array($email, $passResetToken));
+
+    // メール送信 
+    $to      = $_POST['email'];
+    $subject = "パスワード再発行";
+    $message = "
+    ログインのパスワードリセットの申請を受け付けました。
+    パスワードの再設定をご希望の場合は、以下URLをクリックし
+    新しいパスワードをご登録ください。
+    パスワードリセットの申請に心当たりがない場合は、以降の対応は不要となります。
+    パスワードの再設定URL：
+    http://localhost/auth/login/reset.php?pass_reset=$passResetToken
+    ";
+    $headers = "From: posse-ap";
+
+    mb_send_mail($to, $subject, $message, $headers);
+
+    header('Location: http://localhost/auth/login/send_link.php');
+
+    exit;
+  } else {
+    $err_msg = "メールアドレスが登録されていません。";
+  }
+
+}
+
+
+
+
+
+
+?>
+
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>パスワード再発行</title>
+</head>
+
+<body>
+  <div class="util_fullscreen_container">
+    <div class="util_fullscreen util_login">
+      <h1 class="util_login_title">パスワード再発行</h1>
+      <div class="forget">
+        <p class="forget_text">パスワードの再設定が必要となります。</p>
+        <p class="forget_text">恐れ入りますが、登録されたメールアドレスをご入力いただき、受信されたメールの案内に従ってパスワード再設定をお願いします。</p>
+        <br><br><br>
+        <p class="forget_text">登録しているメールアドレス</p>
+        <?php if ($err_msg !== null && $err_msg !== '') {
+          echo "<p class='util_login_error'>" . $err_msg .  "</p>";
+        } ?>
+      </div>
+      <form action="forget.php" method="POST">
+        <input class="util_login_text--box" type="email" name="email" required>
+        <br><br>
+        <input type="submit" name="submit_email" class="util_login_button">
+      </form>
+    </div>
+  </div>
+
+
+</body>
+
+</html>

--- a/src/auth/login/forget.php
+++ b/src/auth/login/forget.php
@@ -35,9 +35,9 @@ if (isset($_POST['submit_email'])) {
     新しいパスワードをご登録ください。
     パスワードリセットの申請に心当たりがない場合は、以降の対応は不要となります。
     パスワードの再設定URL：
-    http://localhost/auth/login/reset.php?pass_reset=$passResetToken
+    http://localhost/auth/login/reset.php?pass_reset=${$passResetToken}
     ";
-    $headers = "From: posse-ap";
+    $headers = ["From" => "posse-ap", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];;
 
     mb_send_mail($to, $subject, $message, $headers);
 
@@ -47,7 +47,6 @@ if (isset($_POST['submit_email'])) {
   } else {
     $err_msg = "メールアドレスが登録されていません。";
   }
-
 }
 
 

--- a/src/auth/login/index.php
+++ b/src/auth/login/index.php
@@ -6,7 +6,7 @@ $err_msg = "";
 
 if (isset($_POST['login'])) {
   $email = $_POST['email'];
-  $password = $_POST['password'];
+  $password = sha1($_POST['password']);
 
   $sql = 'SELECT count(*) FROM users WHERE email = ? AND password = ?';
   $stmt = $db->prepare($sql);

--- a/src/auth/login/index.php
+++ b/src/auth/login/index.php
@@ -72,7 +72,7 @@ if (isset($_POST['login'])) {
         echo "<p>" . $err_msg .  "</p>";
       } ?>
       <div class="text-center text-xs text-gray-400 mt-6">
-        <a href="/">パスワードを忘れた方はこちら</a>
+        <a href="./forget.php">パスワードを忘れた方はこちら</a>
       </div>
     </div>
   </main>

--- a/src/auth/login/reset.php
+++ b/src/auth/login/reset.php
@@ -1,31 +1,24 @@
 <?php
-
 session_start();
 require('../../dbconnect.php');
 
 $email = $_SESSION['email'];
 
 if (isset($_POST['reset'])) {
-  // $password = sha1($_POST['password']);
-  $password = $_POST['password'];
+  $password = sha1($_POST['password']);
 
-
-    $sql = 'UPDATE users
+  $sql = 'UPDATE users
             SET password = ?
             WHERE email = ?';
-    $stmt = $db->prepare($sql);
-    $stmt->execute(array($password, $email));
-    $stmt = null;
-    $db = null;
+  $stmt = $db->prepare($sql);
+  $stmt->execute(array($password, $email));
+  $stmt = null;
+  $db = null;
 
-
-    header('Location: http://localhost/auth/login/reset_done.php');
-    exit;
-  
+  header('Location: http://localhost/auth/login/reset_done.php');
+  exit;
 }
-
 ?>
-
 
 <!DOCTYPE html>
 <html lang="ja">

--- a/src/auth/login/reset.php
+++ b/src/auth/login/reset.php
@@ -1,0 +1,63 @@
+<?php
+
+session_start();
+require('../../dbconnect.php');
+
+$email = $_SESSION['email'];
+
+if (isset($_POST['reset'])) {
+  // $password = sha1($_POST['password']);
+  $password = $_POST['password'];
+
+
+    $sql = 'UPDATE users
+            SET password = ?
+            WHERE email = ?';
+    $stmt = $db->prepare($sql);
+    $stmt->execute(array($password, $email));
+    $stmt = null;
+    $db = null;
+
+
+    header('Location: http://localhost/auth/login/reset_done.php');
+    exit;
+  
+}
+
+?>
+
+
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>パスワードリセット</title>
+</head>
+
+<body>
+  <div class="util_fullscreen_container">
+    <div class="util_fullscreen reset">
+      <h1 class="util_login_title">パスワード再発行</h1>
+      <form action="/auth/login/reset.php" method="POST">
+        <p class="reset_text">メールアドレス：<?= $email ?></p>
+        <div class="util_login_text reset_input">
+          <label class="util_login_text--label" for="password">パスワード：</label>
+          <input class="util_login_text--box" type="password" name="password" id="password" required>
+          <i class="fas fa-eye-slash" id="togglePassword"></i>
+        </div>
+        <div class="util_login_text reset_input">
+          <input type="submit" name="reset" value="リセット" class="util_login_button">
+        </div>
+      </form>
+    </div>
+  </div>
+
+
+
+
+</body>
+
+

--- a/src/auth/login/reset_done.php
+++ b/src/auth/login/reset_done.php
@@ -1,0 +1,31 @@
+<?php
+session_start();
+require('../../dbconnect.php');
+
+?>
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/normalize.css">
+  <link rel="stylesheet" href="/css/style.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
+  <title>パスワードリセット完了</title>
+</head>
+
+<body>
+  <div class="util_fullscreen_container">
+    <div class="util_fullscreen util_fullscreen--small">
+      <h1 class="util_login_title util_login_title--long">パスワード再発行</h1>
+      <div class="reset_done">
+        <p class="reset_done_text">パスワード再発行が完了いたしました。</p>
+        <a class="util_login_link" href="./index.php">ログイン画面に戻る</a>
+      </div>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/auth/login/send_link.php
+++ b/src/auth/login/send_link.php
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>パスワード再発行メール送信完了</title>
+</head>
+
+
+<body>
+  <div class="util_fullscreen_container">
+    <div class="util_fullscreen util_fullscreen--small">
+      <h1 class="util_login_title">パスワード再発行</h1>
+      <div class="sendlink">
+        <p class="sendlink_text">パスワード再発行のメールが送信されました。</p>
+        <p class="sendlink_text">ご登録されたメールアドレスをご確認ください。</p>
+      </div>
+    </div>
+  </div>
+</body>
+
+
+</html>


### PR DESCRIPTION
## 関連イシュー
#9 
### 終了条件

- [x] パスワード忘れた方はこちらを押すと再発行の処理に進む
- [x] ユーザ自身の画面操作でパスワードを再設定出来る

### 備考

再設定のフローはおまかせ


## 検証したこと
- [x] パスワードを忘れた方はこちらを押す
- [x] 登録したメールアドレスを入力するフォームが出てくる。
- [x] 送信ボタンを押すと、完了画面に遷移するとともに、入力したアドレスにパスワード再設定用のURLが載っているメールが届く。
- [x] そのURLを踏むと、再発行ページに飛ぶ。
- [x] そこで新しいパスワードを入力しリセットボタンを押すと、パスワードが新しくなる。
- [x] データベースを見るとパスワードが変更されていることを確認した。
- [x] パスワード再設定完了画面からログイン画面に遷移し、新しいパスワードを用いてログインを試みてログインができたことを確認した。

## エビデンス
登録したメールアドレスを入力するフォームが出てくる。
<img width="390" alt="image" src="https://user-images.githubusercontent.com/94669039/188884153-7215084a-a1df-47ff-94ca-dc8195ef2d10.png">
送信完了画面
<img width="387" alt="image" src="https://user-images.githubusercontent.com/94669039/188884396-44d2ee73-0972-4b1d-92c1-b5d192c86704.png">
メール

送信ボタンを押すと、入力したアドレスにパスワード再設定用のURLが載っているメールが届く。
<img width="751" alt="image" src="https://user-images.githubusercontent.com/86785032/188916432-c90edc25-4cfd-48ec-845a-b3090c065515.png">

そのURLを踏むと、再発行ページに飛び、再発行する。
<img width="376" alt="image" src="https://user-images.githubusercontent.com/94669039/188885585-bc799625-409a-496c-be1f-b3731b56f2d2.png">
<img width="383" alt="image" src="https://user-images.githubusercontent.com/94669039/188885727-829cc922-32ac-4ae0-be77-c07d068d3880.png">

データベースを見るとパスワードが変更されていることを確認した。
user@posse.comの方
<img width="941" alt="image" src="https://user-images.githubusercontent.com/94669039/188899354-fd01d6aa-c936-47c3-a8a5-36127a927750.png">

パスワード再設定完了画面からログイン画面に遷移し、新しいパスワードを用いてログインを試みて
- かつてのパスワードではログインできないことを確認した。
<img width="384" alt="image" src="https://user-images.githubusercontent.com/94669039/188899735-e9a9b68d-8a03-47d4-87af-c9417b56bdc0.png">

- 新しいパスワードでログインができたことを確認した。
<img width="379" alt="image" src="https://user-images.githubusercontent.com/94669039/188899865-f57c76b7-46f0-44d4-b377-7df363b388b5.png">



