### PR TITLE
#4 自分が参加／不参加／未回答のイベントでフィルタ可能

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -5,21 +5,23 @@ session_start();
 require('./auth/login/login-check.php');
 
 $user_id = $_SESSION['user_id'];
+// URLで受け渡した参加ステータスを取得
 $status = filter_input(INPUT_GET, 'status');
-var_dump($status);
 
+// ステータスに値がある場合（参加or不参加）
 if (isset($status)) {
-  if($status == 'all'){
-  $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id  ORDER BY start_at ASC');
-  $stmt->execute();
+  if ($status == 'all') {
+    $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id  ORDER BY start_at ASC');
+    $stmt->execute();
+    // URLで受け渡した、参加不参加情報をもとに絞り込み
   } else {
     $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE event_attendance.user_id = ? AND event_attendance.status = ? GROUP BY events.id ORDER BY events.start_at ASC");
-  $stmt->execute(array($user_id, $status));
+    $stmt->execute(array($user_id, $status));
   }
+  // ステータスに値がない場合（未回答）event tableには存在するがevent_attendance tableにはないレコードを取得
 } else {
-    // $stmt = $db->prepare("SELECT * FROM events ORDER BY events.start_at ASC" );
-    $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM event_attendance RIGHT OUTER JOIN events ON events.id = event_attendance.event_id WHERE event_attendance.status IS NULL GROUP BY events.id ORDER BY events.start_at ASC;");
-    $stmt->execute(array($_SESSION['user_id']));
+  $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM event_attendance RIGHT OUTER JOIN events ON events.id = event_attendance.event_id WHERE event_attendance.status IS NULL GROUP BY events.id ORDER BY events.start_at ASC;");
+  $stmt->execute(array($_SESSION['user_id']));
 }
 $events = $stmt->fetchAll();
 

--- a/src/index.php
+++ b/src/index.php
@@ -17,7 +17,8 @@ if (isset($status)) {
   $stmt->execute(array($user_id, $status));
   }
 } else {
-    $stmt = $db->prepare("SELECT * FROM events ORDER BY events.start_at ASC" );
+    // $stmt = $db->prepare("SELECT * FROM events ORDER BY events.start_at ASC" );
+    $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM event_attendance RIGHT OUTER JOIN events ON events.id = event_attendance.event_id WHERE event_attendance.status IS NULL GROUP BY events.id ORDER BY events.start_at ASC;");
     $stmt->execute(array($_SESSION['user_id']));
 }
 $events = $stmt->fetchAll();

--- a/src/index.php
+++ b/src/index.php
@@ -6,13 +6,19 @@ require('./auth/login/login-check.php');
 
 $user_id = $_SESSION['user_id'];
 $status = filter_input(INPUT_GET, 'status');
+var_dump($status);
 
 if (isset($status)) {
-  $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE event_attendance.user_id = ? AND event_attendance.status = ? GROUP BY events.id ORDER BY events.start_at ASC");
-  $stmt->execute(array($user_id, $status));
-} else {
+  if($status == 'all'){
   $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id  ORDER BY start_at ASC');
   $stmt->execute();
+  } else {
+    $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE event_attendance.user_id = ? AND event_attendance.status = ? GROUP BY events.id ORDER BY events.start_at ASC");
+  $stmt->execute(array($user_id, $status));
+  }
+} else {
+    $stmt = $db->prepare("SELECT * FROM events ORDER BY events.start_at ASC" );
+    $stmt->execute(array($_SESSION['user_id']));
 }
 $events = $stmt->fetchAll();
 
@@ -56,14 +62,18 @@ function get_day_of_week($w)
       <div id="filter" class="mb-8">
         <h2 class="text-sm font-bold mb-3">フィルター</h2>
         <div class="flex">
-          <a href="./index.php" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white <?php if ($status == null) {
-                                                                                                        echo 'bg-blue-600 text-white';
-                                                                                                      } ?>" id="filter_status_all">全て</a>
+          <a href="./index.php?status=all" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white <?php if ($status == "all") {
+                                                                                                                    echo 'bg-blue-600 text-white';
+                                                                                                                  } ?>">全て</a>
           <a href="./index.php?status=presence" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white <?php if ($status == "presence") {
                                                                                                                         echo 'bg-blue-600 text-white';
-                                                                                                                      } ?>" id="filter_status_presence">参加</a>
-          <!-- <a href="./index.php?status=absense" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">不参加</a>
-          <a href="./index.php" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a> -->
+                                                                                                                      } ?>">参加</a>
+          <a href="./index.php?status=absence" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white <?php if ($status == "absence") {
+                                                                                                                        echo 'bg-blue-600 text-white';
+                                                                                                                      } ?>">不参加</a>
+          <a href="./index.php" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white <?php if ($status == null) {
+                                                                                                        echo 'bg-blue-600 text-white';
+                                                                                                      } ?>">未回答</a>
         </div>
       </div>
 


### PR DESCRIPTION
## 関連イシュー
#4 

### 終了条件

- [x] 画面に参加・不参加・未回答ボタンを表示

- [x] 参加ボタンを押すと参加予定のイベントのみ表示される

- [x] 不参加ボタンを押すと不参加予定のイベントのみ表示される

- [x] 未回答ボタンを押すと未回答のイベントのみ表示される

## 検証したこと

- [x] 画面に参加・不参加・未回答ボタンが表示されること
- [x] 参加ボタンを押すと参加予定のイベントのみ表示されること
- [x] 不参加ボタンを押すと不参加予定のイベントのみ表示されること
- [x] 未回答ボタンを押すと未回答のイベントのみ表示されること
- [x] 参加・不参加・未回答ボタンが、現在選択しているボタンによって色が変更すること

## エビデンス

### サイトの画面

⏬ 全てを選択している状態

![image](https://user-images.githubusercontent.com/94669039/189082418-94c43d7a-d1af-413e-9369-8c8ae838bee2.png)

⏬ 参加を選択している状態

![image](https://user-images.githubusercontent.com/94669039/189082513-5e4ca040-f8ae-4dd0-a7a4-003bc3a72653.png)

⏬ 不参加を選択している状態

![image](https://user-images.githubusercontent.com/94669039/189082591-a348630c-6ebd-476b-ad70-89530adc1323.png)

⏬ 未回答を選択している状態

![image](https://user-images.githubusercontent.com/94669039/189082685-56c571e1-ac3a-4234-8f4a-76c990f8dad6.png)


### ターミナル画面（過去のイベントも含んでいるため、レコード数が多いです）

⏬ 全てを選択している状態（event tableにあるレコード全て）

<img width="1410" alt="スクリーンショット 2022-09-07 19 02 55" src="https://user-images.githubusercontent.com/86845003/188853456-ca47a639-ebfc-413c-a4b3-6effc019da17.png">

⏬ 参加を選択している状態（statusがpresenceのレコード）

<img width="1416" alt="スクリーンショット 2022-09-07 19 02 30" src="https://user-images.githubusercontent.com/86845003/188853502-af544990-37df-488c-9c1c-b040eb3b44ac.png">

⏬ 不参加を選択している状態（statusがabsenceのレコード）

<img width="1412" alt="スクリーンショット 2022-09-07 19 02 01" src="https://user-images.githubusercontent.com/86845003/188853568-c6dffffe-0107-4ae8-9c84-77bc4c32d2f1.png">

⏬ 未回答を選択している状態（statusがNULLのレコード）

<img width="1415" alt="スクリーンショット 2022-09-07 19 04 55" src="https://user-images.githubusercontent.com/86845003/188853614-cfffbe2a-7514-43ca-9b3a-3dda1769e06a.png">
