### PR TITLE
#33 管理画面 Issue1 画面からイベントを登録出来るようにする 項目はイベント名、開催日時、イベント内容は空 

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -60,9 +60,10 @@ DROP TABLE IF EXISTS users;
 CREATE TABLE users (
   id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
   email VARCHAR(255) NOT NULL,
-  password VARCHAR(255) NOT NULL
+  password VARCHAR(255) NOT NULL,
+  is_admin TINYINT DEFAULT 0
 );
 
-INSERT INTO users (email, password) VALUES ("user@posse.com","pass");
+INSERT INTO users (email, password, is_admin) VALUES ("user@posse.com","pass", 1);
 INSERT INTO users (email, password) VALUES ("user2@posse.com","pass");
 

--- a/src/admin.php
+++ b/src/admin.php
@@ -36,12 +36,12 @@ $events = $stmt->fetchAll();
   <main class="bg-gray-100">
     <nav>
       <a href="./login/signup.php">
-        <div>
+        <div class="cursor-pointer w-4/5 p-3 m-10 text-xl text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300 flex items-center justify-center">
           新規ユーザー登録
         </div>
       </a>
       <a href="./event_add.php">
-        <div>
+        <div class="cursor-pointer w-4/5 p-3 m-10 text-xl text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300 flex items-center justify-center">
           イベント追加
         </div>
       </a>

--- a/src/admin.php
+++ b/src/admin.php
@@ -35,8 +35,7 @@ $events = $stmt->fetchAll();
 
   <main class="bg-gray-100">
     <nav>
-<<<<<<< HEAD
-      <a href="./login/signup.php">
+      <a href="./auth/login/signup.php">
         <div class="cursor-pointer w-4/5 p-3 m-10 text-xl text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300 flex items-center justify-center">
           新規ユーザー登録
         </div>
@@ -47,35 +46,6 @@ $events = $stmt->fetchAll();
         </div>
       </a>
     </nav>
-=======
-      <a href="./auth/login/signup.php">
-        <div>
-          新規ユーザー登録
-        </div>
-      </a>
-      <a href="">
-        <div>
-
-        </div>
-      </a>
-    </nav>
-    <div class="w-full mx-auto p-5">
-      <!-- 
-      <div id="filter" class="mb-8">
-        <h2 class="text-sm font-bold mb-3">フィルター</h2>
-        <div class="flex">
-          <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-blue-600 text-white">全て</a>
-          <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">参加</a>
-          <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">不参加</a>
-          <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a>
-        </div>
-      </div>
-      -->
-      <!-- 各イベントカード -->
-      <div id="events-list">
-      </div>
-    </div>
->>>>>>> 7bb82b9464bde4fb5f300dd57860e6a69374f16c
   </main>
 </body>
 

--- a/src/admin.php
+++ b/src/admin.php
@@ -4,12 +4,6 @@ require('dbconnect.php');
 $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id');
 $events = $stmt->fetchAll();
 
-function get_day_of_week($w)
-{
-  $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
-  return $day_of_week_list["$w"];
-}
-
 ?>
 
 <!DOCTYPE html>
@@ -46,72 +40,12 @@ function get_day_of_week($w)
           新規ユーザー登録
         </div>
       </a>
-      <a href="">
+      <a href="./event_add.php">
         <div>
-          
+          イベント追加
         </div>
       </a>
     </nav>
-    <div class="w-full mx-auto p-5">
-      <!-- 
-      <div id="filter" class="mb-8">
-        <h2 class="text-sm font-bold mb-3">フィルター</h2>
-        <div class="flex">
-          <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-blue-600 text-white">全て</a>
-          <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">参加</a>
-          <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">不参加</a>
-          <a href="" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a>
-        </div>
-      </div>
-      -->
-      <!-- 各イベントカード -->
-      <div id="events-list">
-        <div class="flex justify-between items-center mb-3">
-          <h2 class="text-sm font-bold">一覧</h2>
-        </div>
-        <?php foreach ($events as $event) : ?>
-          <?php
-          $start_date = strtotime($event['start_at']);
-          $end_date = strtotime($event['end_at']);
-          $day_of_week = get_day_of_week(date("w", $start_date));
-          $today = strtotime("today");
-          // strtotimeで今日の0:00を取得 star_dateがそれより前であれば、continueで処理をスキップ
-          if ($start_date < $today) {
-            continue;
-          };
-          ?>
-
-          <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
-            <div>
-              <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>
-              <p><?php echo date("Y年m月d日（${day_of_week}）", $start_date); ?></p>
-              <p class="text-xs text-gray-600">
-                <?php echo date("H:i", $start_date) . "~" . date("H:i", $end_date); ?>
-              </p>
-            </div>
-            <div class="flex flex-col justify-between text-right">
-              <div>
-                <?php if ($event['id'] % 3 === 1) : ?>
-                  <!--
-                  <p class="text-sm font-bold text-yellow-400">未回答</p>
-                  <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $end_date)); ?></p>
-                  -->
-                <?php elseif ($event['id'] % 3 === 2) : ?>
-                  <!-- 
-                  <p class="text-sm font-bold text-gray-300">不参加</p>
-                  -->
-                <?php else : ?>
-                  <!-- 
-                  <p class="text-sm font-bold text-green-400">参加</p>
-                  -->
-                <?php endif; ?>
-              </div>
-              <p class="text-sm"><span class="text-xl"><?php echo $event['total_participants']; ?></span>人参加 ></p>
-            </div>
-          </div>
-        <?php endforeach; ?>
-      </div>
-    </div>
   </main>
 </body>
 

--- a/src/event_add.php
+++ b/src/event_add.php
@@ -1,0 +1,52 @@
+<?php
+session_start();
+require('./dbconnect.php');
+
+// 画像以外の更新
+if (isset($_POST['submit'])) {
+
+  $event_name = $_POST['event_name'];
+  $event_start = $_POST['event_start'];
+  $event_end = $_POST['event_end'];
+
+  $sql = 'INSERT INTO events(name, start_at, end_at) VALUES (?, ?, ?)';
+  $stmt = $db->prepare($sql);
+  $stmt->execute(array($event_name, $event_start, $event_end));
+
+  // header('Location: home.php');
+  exit;
+}
+?>
+<!DOCTYPE html>
+<html>
+
+<head>
+  <link href="https://use.fontawesome.com/releases/v5.15.4/css/all.css" rel="stylesheet">
+</head>
+
+<body>
+  <div class="change">
+    <form action="" method="post" id="postForm">
+      <div>
+        <label for="event_name" id="event_name">イベント名</label>
+        <input type="text" name="event_name">
+      </div>
+      <div>
+        <label for="event_start">開始日時</label>
+        <input type="datetime-local" name="event_start">
+      </div>
+      <div>
+        <label for="event_end">終了日時</label>
+        <input type="datetime-local" name="event_end">
+      </div>
+      <div>
+        <label for="event_detail">イベント詳細</label>
+        <textarea name="event_detail"></textarea>
+      </div>
+      <input type="submit" value="追加" name="submit">
+    </form>
+  </div>
+  </div>
+</body>
+
+</html>

--- a/src/event_add.php
+++ b/src/event_add.php
@@ -31,14 +31,14 @@ if (isset($_POST['submit'])) {
     </div>
     <form action="" method="post" id="postForm">
       <p class="sub mb-0 mt-3">イベント名</p>
-      <input type="text" name="event_name" class="event__add__form__event__name  event__add__form__item w-full p-4 text-sm mb-2 h-14 rounded">
+      <input type="text" name="event_name">
       <p class="sub mb-0 mt-3">開始日時</p>
-      <input type="datetime-local" name="event_start" class="event__add__form__event__date event__add__form__item w-full p-4 text-sm mb-3 rounded">
+      <input type="datetime-local" name="event_start">
       <p class="sub mb-0 mt-3">終了日時</p>
-      <input type="datetime-local" name="event_end" class="event__add__form__event__date event__add__form__item w-full p-4 text-sm mb-3 rounded">
+      <input type="datetime-local" name="event_end">
       <p class="sub mb-0 mt-3">イベント詳細</p>
-      <input type="text" name="event_detail" class="event__add__form__event__date event__add__form__item w-full p-4 text-sm mb-3 rounded">
-      <input type="submit" value="送信" name="submit" class="event__add__form__button cursor-pointer w-full p-3 text-md text-white rounded-3xl posse-gradatation-blue">
+      <input type="text" name="event_detail">
+      <input type="submit" value="送信" name="submit">
     </form>
   </div>
 </body>

--- a/src/event_add.php
+++ b/src/event_add.php
@@ -25,18 +25,18 @@ if (isset($_POST['submit'])) {
 </head>
 
 <body>
-  <div class="bg-gray-100 h-screen w-full py-8 px-7">
-    <div class="form w-full mx-auto py-10">
-      <h2 class="title text-md font-bold mb-3">イベント追加</h2>
+  <div>
+    <div>
+      <h2>イベント追加</h2>
     </div>
     <form action="" method="post" id="postForm">
-      <p class="sub mb-0 mt-3">イベント名</p>
+      <p>イベント名</p>
       <input type="text" name="event_name">
-      <p class="sub mb-0 mt-3">開始日時</p>
+      <p>開始日時</p>
       <input type="datetime-local" name="event_start">
-      <p class="sub mb-0 mt-3">終了日時</p>
+      <p>終了日時</p>
       <input type="datetime-local" name="event_end">
-      <p class="sub mb-0 mt-3">イベント詳細</p>
+      <p>イベント詳細</p>
       <input type="text" name="event_detail">
       <input type="submit" value="送信" name="submit">
     </form>

--- a/src/event_add.php
+++ b/src/event_add.php
@@ -25,27 +25,21 @@ if (isset($_POST['submit'])) {
 </head>
 
 <body>
-  <div class="change">
+  <div class="bg-gray-100 h-screen w-full py-8 px-7">
+    <div class="form w-full mx-auto py-10">
+      <h2 class="title text-md font-bold mb-3">イベント追加</h2>
+    </div>
     <form action="" method="post" id="postForm">
-      <div>
-        <label for="event_name" id="event_name">イベント名</label>
-        <input type="text" name="event_name">
-      </div>
-      <div>
-        <label for="event_start">開始日時</label>
-        <input type="datetime-local" name="event_start">
-      </div>
-      <div>
-        <label for="event_end">終了日時</label>
-        <input type="datetime-local" name="event_end">
-      </div>
-      <div>
-        <label for="event_detail">イベント詳細</label>
-        <textarea name="event_detail"></textarea>
-      </div>
-      <input type="submit" value="追加" name="submit">
+      <p class="sub mb-0 mt-3">イベント名</p>
+      <input type="text" name="event_name" class="event__add__form__event__name  event__add__form__item w-full p-4 text-sm mb-2 h-14 rounded">
+      <p class="sub mb-0 mt-3">開始日時</p>
+      <input type="datetime-local" name="event_start" class="event__add__form__event__date event__add__form__item w-full p-4 text-sm mb-3 rounded">
+      <p class="sub mb-0 mt-3">終了日時</p>
+      <input type="datetime-local" name="event_end" class="event__add__form__event__date event__add__form__item w-full p-4 text-sm mb-3 rounded">
+      <p class="sub mb-0 mt-3">イベント詳細</p>
+      <input type="text" name="event_detail" class="event__add__form__event__date event__add__form__item w-full p-4 text-sm mb-3 rounded">
+      <input type="submit" value="送信" name="submit" class="event__add__form__button cursor-pointer w-full p-3 text-md text-white rounded-3xl posse-gradatation-blue">
     </form>
-  </div>
   </div>
 </body>
 

--- a/src/event_add.php
+++ b/src/event_add.php
@@ -21,24 +21,37 @@ if (isset($_POST['submit'])) {
 <html>
 
 <head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="https://use.fontawesome.com/releases/v5.15.4/css/all.css" rel="stylesheet">
+  <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+  <title>Schedule | POSSE</title>
+
 </head>
 
 <body>
-  <div>
-    <div>
-      <h2>イベント追加</h2>
+<header class="h-16">
+    <div class="flex justify-between items-center w-full h-full mx-auto pl-2 pr-5">
+      <div class="h-full">
+        <img src="/img/header-logo.png" alt="" class="h-full">
+      </div>
     </div>
-    <form action="" method="post" id="postForm">
-      <p>イベント名</p>
-      <input type="text" name="event_name">
-      <p>開始日時</p>
-      <input type="datetime-local" name="event_start">
-      <p>終了日時</p>
-      <input type="datetime-local" name="event_end">
-      <p>イベント詳細</p>
-      <input type="text" name="event_detail">
-      <input type="submit" value="送信" name="submit">
+  </header>
+  <div class="bg-gray-100 p-4">
+    <div>
+      <h2 class="text-2xl mt-3 mb-3 font-bold">イベント追加</h2>
+    </div>
+    <form action="" method="post" id="postForm" class="p-3">
+      <p class="text-xl pt-4 pb-4">イベント名</p>
+      <input type="text" name="event_name" class="w-full">
+      <p class="text-xl pt-5 pb-4">開始日時</p>
+      <input type="datetime-local" name="event_start" class="w-full">
+      <p class="text-xl pt-5 pb-4">終了日時</p>
+      <input type="datetime-local" name="event_end" class="w-full">
+      <p class="text-xl pt-5 pb-4">イベント詳細</p>
+      <input type="text" name="event_detail" class="w-full">
+      <input type="submit" value="送信" name="submit" class="cursor-pointer w-4/5 p-3 m-10 text-xl text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300 flex items-center justify-center"> 
     </form>
   </div>
 </body>

--- a/src/event_add.php
+++ b/src/event_add.php
@@ -13,7 +13,7 @@ if (isset($_POST['submit'])) {
   $stmt = $db->prepare($sql);
   $stmt->execute(array($event_name, $event_start, $event_end));
 
-  // header('Location: home.php');
+  header('Location: admin.php');
   exit;
 }
 ?>

--- a/src/index.php
+++ b/src/index.php
@@ -7,6 +7,12 @@ require('./auth/login/login-check.php');
 $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id  ORDER BY start_at ASC');
 $events = $stmt->fetchAll();
 
+$user_id = $_SESSION['user_id'];
+
+$sql = 'SELECT COUNT(id) FROM users WHERE is_admin = 1 AND id = ?';
+$stmt = $db->query($sql, $user_id);
+$is_admin = $stmt->fetch();
+
 function get_day_of_week($w)
 {
   $day_of_week_list = ['日', '月', '火', '水', '木', '金', '土'];
@@ -38,7 +44,13 @@ function get_day_of_week($w)
       </div>
       -->
       <!-- ここにユーザーidを埋め込む -->
+      <?php if ($is_admin[0] != 0) {?>
       <input type="hidden" name="user_id" value="15">
+      <?php } else { ?>
+        <input type="hidden" name="user_id" value="15">
+      <?php } ?>
+
+      <a href="./admin.php">管理画面へ</a>
     </div>
   </header>
 

--- a/src/index.php
+++ b/src/index.php
@@ -17,8 +17,8 @@ if (isset($status)) {
 $events = $stmt->fetchAll();
 
 // ユーザーが管理者かを確認
-$sql = 'SELECT COUNT(id) FROM users WHERE is_admin = 1 AND id = ?';
-$stmt = $db->query($sql, $user_id);
+$stmt = $db->prepare('SELECT COUNT(id) FROM users WHERE is_admin = 1 AND id = ?');
+$stmt->execute(array($user_id));
 $is_admin = $stmt->fetch();
 
 function get_day_of_week($w)

--- a/src/index.php
+++ b/src/index.php
@@ -54,7 +54,7 @@ function get_day_of_week($w)
       <input type="hidden" name="user_id" value="<?= $_SESSION['user_id'] ?>">
 
       <?php if ($is_admin[0] != 0) { ?>
-        <a href="./admin.php">管理画面へ</a>
+        <a href="./admin.php" class="cursor-pointer p-2 text-sm text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300 flex items-center justify-center">管理画面へ</a>
       <?php } ?>
 
     </div>


### PR DESCRIPTION
## 関連イシュー
#33 

### 終了条件

- [x] 管理画面からイベント名、開催日時を入力して、イベント登録できる
- [x] 管理画面には管理者のみログイン出来る

## 検証したこと
- [x] 管理者権限のアカウントでログイン
- [x] イベント名と開催日時を入力して、イベント登録する（詳細にデータを入れるのは次のissueなのでこの段階では空）
- [x] 登録したイベントがユーザーのイベント一覧に表示されていることを確認

## エビデンス
管理者権限付きアカウントでログイン
<img width="319" alt="image" src="https://user-images.githubusercontent.com/86785032/188900985-35fe28ab-3b0a-4d77-954f-fab78c40edea.png">
<img width="322" alt="image" src="https://user-images.githubusercontent.com/86785032/188922485-19648a14-de23-4e21-a611-70c061a76f25.png">
（管理者権限付きではないアカウントでログインした場合、「管理画面へ」が表示されない）
<img width="321" alt="image" src="https://user-images.githubusercontent.com/86785032/188922664-e16aeec1-16c5-4f76-a580-1d3c11b8fcc8.png">
<img width="420" alt="image" src="https://user-images.githubusercontent.com/86785032/188901287-2799fbfb-9c22-4289-9626-65006224bcaf.png">


イベント追加画面にて追加
<img width="320" alt="image" src="https://user-images.githubusercontent.com/86785032/188922906-0aae95fe-4641-47c5-a924-33a5c5f33295.png">
イベント一覧に追加されていることを確認
<img width="321" alt="image" src="https://user-images.githubusercontent.com/86785032/188923129-116481b1-82a2-4322-ad53-f5ce1a758d4c.png">


