### PR TITLE
#15 イベント参加管理 Issue4 トップページに自身の回答状況を表示する

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -8,10 +8,10 @@ $user_id = $_SESSION['user_id'];
 $status = filter_input(INPUT_GET, 'status');
 
 if (isset($status)) {
-  $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE event_attendance.user_id = ? AND event_attendance.status = ? GROUP BY events.id ORDER BY events.start_at ASC");
+  $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE event_attendance.user_id = ? AND event_attendance.status = ? GROUP BY events.id ORDER BY events.start_at ASC");
   $stmt->execute(array($user_id, $status));
 } else {
-  $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id  ORDER BY start_at ASC');
+  $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id  ORDER BY start_at ASC');
   $stmt->execute();
 }
 $events = $stmt->fetchAll();

--- a/src/index.php
+++ b/src/index.php
@@ -79,6 +79,11 @@ function get_day_of_week($w)
           $day_of_week = get_day_of_week(date("w", $start_date));
           $today = strtotime("today");
 
+          // イベントごとのステータス取得
+          $stmt = $db->prepare('SELECT user_id, status FROM event_attendance WHERE event_id = ? AND user_id = ?');
+          $stmt->execute(array($event['id'], $user_id));
+          $participation_status = $stmt->fetch();
+
           // strtotimeで今日の0:00を取得 star_dateがそれより前であれば、continueで処理をスキップ
           if ($start_date < $today) {
             continue;
@@ -95,19 +100,13 @@ function get_day_of_week($w)
             </div>
             <div class="flex flex-col justify-between text-right">
               <div>
-                <?php if ($event['id'] % 3 === 1) : ?>
-                  <!--
+                <?php if (is_null($participation_status['status'])) : ?>
                   <p class="text-sm font-bold text-yellow-400">未回答</p>
-                  <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日", strtotime('-3 day', $end_date)); ?></p>
-                  -->
-                <?php elseif ($event['id'] % 3 === 2) : ?>
-                  <!-- 
+                  <p class="text-xs text-yellow-400">期限 <?php echo date("m月d日 H:i:s", strtotime('-3 day', $end_date)); ?></p>
+                <?php elseif ($participation_status['status'] == 'absence') : ?>
                   <p class="text-sm font-bold text-gray-300">不参加</p>
-                  -->
-                <?php else : ?>
-                  <!-- 
+                <?php elseif ($participation_status['status'] == 'presence') : ?>
                   <p class="text-sm font-bold text-green-400">参加</p>
-                  -->
                 <?php endif; ?>
               </div>
               <p class="text-sm"><span class="text-xl"><?php echo $event['total_participants']; ?></span>人参加 ></p>

--- a/src/index.php
+++ b/src/index.php
@@ -84,6 +84,11 @@ function get_day_of_week($w)
           $stmt->execute(array($event['id'], $user_id));
           $participation_status = $stmt->fetch();
 
+          // 参加者合計
+          $stmt = $db->prepare('SELECT user_id, status FROM event_attendance WHERE event_id = ? AND user_id = ?');
+          $stmt->execute(array($event['id'], $user_id));
+          $participation_status = $stmt->fetch();
+
           // strtotimeで今日の0:00を取得 star_dateがそれより前であれば、continueで処理をスキップ
           if ($start_date < $today) {
             continue;

--- a/src/index.php
+++ b/src/index.php
@@ -84,10 +84,10 @@ function get_day_of_week($w)
           $stmt->execute(array($event['id'], $user_id));
           $participation_status = $stmt->fetch();
 
-          // 参加者合計
-          $stmt = $db->prepare('SELECT user_id, status FROM event_attendance WHERE event_id = ? AND user_id = ?');
-          $stmt->execute(array($event['id'], $user_id));
-          $participation_status = $stmt->fetch();
+          // 参加者の合計を求める
+          $stmt = $db->prepare("SELECT COUNT(user_id) FROM event_attendance WHERE event_id = ? AND status = 'presence'");
+          $stmt->execute(array($event['id']));
+          $participants_total = $stmt->fetch();
 
           // strtotimeで今日の0:00を取得 star_dateがそれより前であれば、continueで処理をスキップ
           if ($start_date < $today) {
@@ -114,7 +114,7 @@ function get_day_of_week($w)
                   <p class="text-sm font-bold text-green-400">参加</p>
                 <?php endif; ?>
               </div>
-              <p class="text-sm"><span class="text-xl"><?php echo $event['total_participants']; ?></span>人参加 ></p>
+              <p class="text-sm"><span class="text-xl"><?= $participants_total[0] ?></span>人参加 ></p>
             </div>
           </div>
         <?php endforeach; ?>


### PR DESCRIPTION
## 関連イシュー
#15 

### 終了条件
トップページの対象イベントに回答状況を表示する
- [x] まだ回答していない場合は未回答
- [x] 参加の場合は参加
- [x] 不参加の場合は不参加

## 検証したこと
- [x] 未回答のイベントはイベントの右上で未回答と表示されることを確認。期限も表示される（何時何分何秒まで表示するよう少し修正）
- [x] 参加を押すとトップ画面がレフレッシュされ、右上で参加と表示される
- [x] 不参加を押すとトップ画面がレフレッシュされ、右上で不参加と表示される

## エビデンス

未回答：
<img width="306" alt="image" src="https://user-images.githubusercontent.com/86785032/188921185-058f1343-c1c9-41c5-95e6-19c2dc6fefd7.png">

参加するを押した場合のトップ画面：
<img width="301" alt="image" src="https://user-images.githubusercontent.com/86785032/188921218-11412647-aceb-416e-a57e-8f5bc012f7d3.png">

参加しないを押した場合：
<img width="296" alt="image" src="https://user-images.githubusercontent.com/86785032/188924941-9d58afed-70c7-4084-9968-23c76c95eed0.png">
