### PR TITLE
#28 イベント参加管理 Issue5 イベント詳細画面のイベント参加人数をクリックすると、 参加者が一覧表示される

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -61,9 +61,10 @@ DROP TABLE IF EXISTS users;
 CREATE TABLE users (
   id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
   email VARCHAR(255) NOT NULL,
-  password VARCHAR(255) NOT NULL
+  password VARCHAR(255) NOT NULL,  
+  name VARCHAR(255)
 );
 
-INSERT INTO users (email, password) VALUES ("user@posse.com","pass");
-INSERT INTO users (email, password) VALUES ("user2@posse.com","pass");
+INSERT INTO users (email, password, name) VALUES ("user@posse.com","pass", "山田康介");
+INSERT INTO users (email, password, name) VALUES ("user2@posse.com","pass", "寺岡修馬");
 

--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -50,10 +50,10 @@ INSERT INTO events SET name='海', start_at='2022/09/14 18:00', end_at='2022/09/
 INSERT INTO events SET name='浅草', start_at='2022/09/15 18:00', end_at='2022/09/15 22:00';
 INSERT INTO events SET name='横モク', start_at='2022/09/16 18:00', end_at='2022/09/16 22:00';
 INSERT INTO event_attendance SET event_id=1, user_id = 1, status="presence";
-INSERT INTO event_attendance SET event_id=1, user_id = 1, status="presence";
-INSERT INTO event_attendance SET event_id=1, user_id = 1, status="presence";
+INSERT INTO event_attendance SET event_id=1, user_id = 2, status="presence";
+INSERT INTO event_attendance SET event_id=1, user_id = 3, status="presence";
 INSERT INTO event_attendance SET event_id=2, user_id = 1, status="presence";
-INSERT INTO event_attendance SET event_id=2, user_id = 1, status="presence";
+INSERT INTO event_attendance SET event_id=2, user_id = 2, status="presence";
 INSERT INTO event_attendance SET event_id=3, user_id = 1, status="presence";
 
 DROP TABLE IF EXISTS users;

--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -67,4 +67,5 @@ CREATE TABLE users (
 
 INSERT INTO users (email, password, name) VALUES ("user@posse.com","pass", "山田康介");
 INSERT INTO users (email, password, name) VALUES ("user2@posse.com","pass", "寺岡修馬");
+INSERT INTO users (email, password, name) VALUES ("user3@posse.com","pass", "大友裕太");
 

--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -39,16 +39,16 @@ INSERT INTO events SET name='横モク', start_at='2021/08/23 21:00', end_at='20
 INSERT INTO events SET name='スペモク', start_at='2021/08/24 20:00', end_at='2021/08/24 22:00';
 INSERT INTO events SET name='遊び', start_at='2021/09/22 18:00', end_at='2021/09/22 22:00';
 INSERT INTO events SET name='ハッカソン', start_at='2021/09/03 10:00', end_at='2021/09/03 22:00';
-INSERT INTO events SET name='遊び', start_at='2022/09/07 18:00', end_at='2022/09/06 22:00';
-INSERT INTO events SET name='スペモク', start_at='2022/09/08 18:00', end_at='2022/09/06 22:00';
-INSERT INTO events SET name='遊び', start_at='2022/09/09 18:00', end_at='2022/09/06 22:00';
-INSERT INTO events SET name='横モク', start_at='2022/09/10 18:00', end_at='2022/09/06 22:00';
-INSERT INTO events SET name='花火大会', start_at='2022/09/11 18:00', end_at='2022/09/06 22:00';
-INSERT INTO events SET name='スペモク', start_at='2022/09/12 18:00', end_at='2022/09/06 22:00';
-INSERT INTO events SET name='遊び', start_at='2022/09/13 18:00', end_at='2022/09/06 22:00';
-INSERT INTO events SET name='海', start_at='2022/09/14 18:00', end_at='2022/09/06 22:00';
-INSERT INTO events SET name='浅草', start_at='2022/09/15 18:00', end_at='2022/09/06 22:00';
-INSERT INTO events SET name='横モク', start_at='2022/09/16 18:00', end_at='2022/09/06 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/07 18:00', end_at='2022/09/07 22:00';
+INSERT INTO events SET name='スペモク', start_at='2022/09/08 18:00', end_at='2022/09/08 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/09 18:00', end_at='2022/09/09 22:00';
+INSERT INTO events SET name='横モク', start_at='2022/09/10 18:00', end_at='2022/09/10 22:00';
+INSERT INTO events SET name='花火大会', start_at='2022/09/11 18:00', end_at='2022/09/01 22:00';
+INSERT INTO events SET name='スペモク', start_at='2022/09/12 18:00', end_at='2022/09/12 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/13 18:00', end_at='2022/09/13 19:00';
+INSERT INTO events SET name='海', start_at='2022/09/14 18:00', end_at='2022/09/14 22:00';
+INSERT INTO events SET name='浅草', start_at='2022/09/15 18:00', end_at='2022/09/15 22:00';
+INSERT INTO events SET name='横モク', start_at='2022/09/16 18:00', end_at='2022/09/16 22:00';
 INSERT INTO event_attendance SET event_id=1, user_id = 1, status="presence";
 INSERT INTO event_attendance SET event_id=1, user_id = 2, status="presence";
 INSERT INTO event_attendance SET event_id=1, user_id = 3, status="presence";
@@ -56,53 +56,16 @@ INSERT INTO event_attendance SET event_id=2, user_id = 1, status="presence";
 INSERT INTO event_attendance SET event_id=2, user_id = 2, status="presence";
 INSERT INTO event_attendance SET event_id=3, user_id = 1, status="presence";
 
-
--- ユーザーログイン
 DROP TABLE IF EXISTS users;
 
 CREATE TABLE users (
   id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
   email VARCHAR(255) NOT NULL,
   password VARCHAR(255) NOT NULL,  
-  name VARCHAR(255),
-  is_admin TINYINT DEFAULT 0
+  name VARCHAR(255)
 );
 
-INSERT INTO 
-  users 
-SET
-  email = "user@posse.com",
-  password = sha1('pass'),
-  name="山田康介",   
-  is_admin = 1;
-
-INSERT INTO 
-  users 
-SET
-  email = "user2@posse.com",
-  password = sha1('pass'),
-  name="寺岡修馬";
-
-INSERT INTO 
-  users 
-SET
-  email = "user3@posse.com",
-  password = sha1('pass'),
-  name="大友裕太";
-
--- パスワードリセット関連です。
-
-DROP TABLE IF EXISTS user_password_reset;
-
-CREATE TABLE user_password_reset (
-    id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
-    email VARCHAR(255) NOT NULL,
-    pass_token VARCHAR(255) NOT NULL,
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-
-INSERT INTO
-    user_password_reset(email, pass_token);
-VALUES
-    ("test@test.com", "test");
+INSERT INTO users (email, password, name) VALUES ("user@posse.com","pass", "山田康介");
+INSERT INTO users (email, password, name) VALUES ("user2@posse.com","pass", "寺岡修馬");
+INSERT INTO users (email, password, name) VALUES ("user3@posse.com","pass", "大友裕太");
 

--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -44,15 +44,9 @@ INSERT INTO events SET name='遊び', start_at='2022/09/07 18:00', end_at='2022/
 INSERT INTO events SET name='スペモク', start_at='2022/09/08 18:00', end_at='2022/09/08 22:00';
 INSERT INTO events SET name='遊び', start_at='2022/09/09 18:00', end_at='2022/09/09 22:00';
 INSERT INTO events SET name='横モク', start_at='2022/09/10 18:00', end_at='2022/09/10 22:00';
-<<<<<<< HEAD
-INSERT INTO events SET name='花火大会', start_at='2022/09/11 18:00', end_at='2022/09/01 22:00';
-INSERT INTO events SET name='スペモク', start_at='2022/09/12 18:00', end_at='2022/09/12 22:00';
-INSERT INTO events SET name='遊び', start_at='2022/09/13 18:00', end_at='2022/09/13 19:00';
-=======
 INSERT INTO events SET name='花火大会', start_at='2022/09/11 18:00', end_at='2022/09/11 22:00';
 INSERT INTO events SET name='スペモク', start_at='2022/09/12 18:00', end_at='2022/09/12 22:00';
 INSERT INTO events SET name='遊び', start_at='2022/09/13 18:00', end_at='2022/09/13 22:00';
->>>>>>> 80ff37527206a14622f7950f21cbf11ef873f668
 INSERT INTO events SET name='海', start_at='2022/09/14 18:00', end_at='2022/09/14 22:00';
 INSERT INTO events SET name='浅草', start_at='2022/09/15 18:00', end_at='2022/09/15 22:00';
 INSERT INTO events SET name='横モク', start_at='2022/09/16 18:00', end_at='2022/09/16 22:00';

--- a/src/api/getModalInfo.php
+++ b/src/api/getModalInfo.php
@@ -31,9 +31,9 @@ if (isset($_GET['eventId'])) {
     $participants_total = $stmt->fetch();
 
     // 参加者の情報を取得
-    $stmt = $db->prepare('SELECT users.name FROM users INNER JOIN event_attendance ON users.id = event_attendance.user_id WHERE event_id = ? AND user_id = ?');
-    $stmt->execute(array($eventId, $userId));
-    $participation_status = $stmt->fetch();
+    $stmt = $db->prepare("SELECT users.name FROM users INNER JOIN event_attendance ON users.id = event_attendance.user_id WHERE event_id = ? AND event_attendance.status = 'presence'");
+    $stmt->execute(array($eventId));
+    $participant_names = $stmt->fetchAll();
 
 
     $array = [
@@ -47,6 +47,7 @@ if (isset($_GET['eventId'])) {
       'message' => $eventMessage,
       'status' => $status,
       'participation_status' => $participation_status['status'],
+      'participant_names' => $participant_names,
       'deadline' => date("m月d日 H:i:s", strtotime('-3 day', $end_date)),
     ];
     

--- a/src/api/getModalInfo.php
+++ b/src/api/getModalInfo.php
@@ -20,6 +20,7 @@ if (isset($_GET['eventId'])) {
     elseif ($event['id'] % 3 === 2) $status = 1;
     else $status = 2;
 
+    
     $stmt = $db->prepare('SELECT user_id, status FROM event_attendance WHERE event_id = ? AND user_id = ?');
     $stmt->execute(array($eventId, $userId));
     $participation_status = $stmt->fetch();

--- a/src/api/getModalInfo.php
+++ b/src/api/getModalInfo.php
@@ -4,7 +4,6 @@ require('../dbconnect.php');
 header('Content-Type: application/json; charset=UTF-8');
 
 if (isset($_GET['eventId'])) {
-  $userId = $_SESSION['user_id'];
   $eventId = htmlspecialchars($_GET['eventId']);
   $userId = $_SESSION['user_id'];
   try {
@@ -48,6 +47,7 @@ if (isset($_GET['eventId'])) {
       'message' => $eventMessage,
       'status' => $status,
       'participation_status' => $participation_status['status'],
+      'participant_names' => $participant_names,
       'deadline' => date("m月d日 H:i:s", strtotime('-3 day', $end_date)),
     ];
     

--- a/src/api/getModalInfo.php
+++ b/src/api/getModalInfo.php
@@ -30,6 +30,12 @@ if (isset($_GET['eventId'])) {
     $stmt->execute(array($event['id']));
     $participants_total = $stmt->fetch();
 
+    // 参加者の情報を取得
+    $stmt = $db->prepare('SELECT users.name FROM users INNER JOIN event_attendance ON users.id = event_attendance.user_id WHERE event_id = ? AND user_id = ?');
+    $stmt->execute(array($eventId, $userId));
+    $participation_status = $stmt->fetch();
+
+
     $array = [
       'id' => $event['id'],
       'name' => $event['name'],

--- a/src/api/getModalInfo.php
+++ b/src/api/getModalInfo.php
@@ -1,9 +1,11 @@
 <?php
+session_start();
 require('../dbconnect.php');
 header('Content-Type: application/json; charset=UTF-8');
 
 if (isset($_GET['eventId'])) {
   $eventId = htmlspecialchars($_GET['eventId']);
+  $userId = $_SESSION['user_id'];
   try {
     $stmt = $db->prepare('SELECT events.id, events.name, events.start_at, events.end_at FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.id = ? GROUP BY events.id');
     $stmt->execute(array($eventId));

--- a/src/index.php
+++ b/src/index.php
@@ -91,6 +91,11 @@ function get_day_of_week($w)
           $stmt->execute(array($event['id']));
           $participants_total = $stmt->fetch();
 
+          // 参加者の情報を取得
+          $stmt = $db->prepare("SELECT users.name FROM users INNER JOIN event_attendance ON users.id = event_attendance.user_id WHERE event_id = ? AND event_attendance.status = 'presence'");
+          $stmt->execute(array($event['id']));
+          $participant_names = $stmt->fetchAll();
+
           // strtotimeで今日の0:00を取得 star_dateがそれより前であれば、continueで処理をスキップ
           if ($start_date < $today) {
             continue;
@@ -116,7 +121,17 @@ function get_day_of_week($w)
                   <p class="text-sm font-bold text-green-400">参加</p>
                 <?php endif; ?>
               </div>
-              <p class="text-sm"><span class="text-xl"><?= $participants_total[0] ?></span>人参加 ></p>
+              <div class="accordion">
+                <a class="accordion_click">
+                  <p class="text-sm"><span class="text-xl"><?= $participants_total[0] ?></span>人参加 ></p>
+                </a>
+                <ul style="display: none">
+                  <p class="font-bold">参加者一覧：</p>
+                  <?php foreach ($participant_names as $participant_name) { ?>
+                    <li><?= $participant_name[0] ?></li>
+                  <?php }?>
+                </ul>
+              </div>
             </div>
           </div>
         <?php endforeach; ?>

--- a/src/index.php
+++ b/src/index.php
@@ -70,14 +70,18 @@ function get_day_of_week($w)
       <div id="filter" class="mb-8">
         <h2 class="text-sm font-bold mb-3">フィルター</h2>
         <div class="flex">
-          <a href="./index.php" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white <?php if ($status == null) {
-                                                                                                        echo 'bg-blue-600 text-white';
-                                                                                                      } ?>" id="filter_status_all">全て</a>
+          <a href="./index.php?status=all" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white <?php if ($status == "all") {
+                                                                                                                    echo 'bg-blue-600 text-white';
+                                                                                                                  } ?>">全て</a>
           <a href="./index.php?status=presence" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white <?php if ($status == "presence") {
                                                                                                                         echo 'bg-blue-600 text-white';
-                                                                                                                      } ?>" id="filter_status_presence">参加</a>
-          <!-- <a href="./index.php?status=absense" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">不参加</a>
-          <a href="./index.php" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a> -->
+                                                                                                                      } ?>">参加</a>
+          <a href="./index.php?status=absence" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white <?php if ($status == "absence") {
+                                                                                                                        echo 'bg-blue-600 text-white';
+                                                                                                                      } ?>">不参加</a>
+          <a href="./index.php" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white <?php if ($status == null) {
+                                                                                                        echo 'bg-blue-600 text-white';
+                                                                                                      } ?>">未回答</a>
         </div>
       </div>
 
@@ -141,7 +145,7 @@ function get_day_of_week($w)
                   <p class="font-bold">参加者一覧：</p>
                   <?php foreach ($participant_names as $participant_name) { ?>
                     <li><?= $participant_name[0] ?></li>
-                  <?php }?>
+                  <?php } ?>
                 </ul>
               </div>
             </div>

--- a/src/index.php
+++ b/src/index.php
@@ -31,6 +31,8 @@ function get_day_of_week($w)
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet">
+  <!-- アコーディオンのためにjqueryロード -->
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
   <title>Schedule | POSSE</title>
 </head>
 

--- a/src/index.php
+++ b/src/index.php
@@ -5,30 +5,16 @@ session_start();
 require('./auth/login/login-check.php');
 
 $user_id = $_SESSION['user_id'];
-// URLで受け渡した参加ステータスを取得
 $status = filter_input(INPUT_GET, 'status');
 
-// ステータスに値がある場合（参加or不参加）
 if (isset($status)) {
-  if ($status == 'all') {
-    $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id  ORDER BY start_at ASC');
-    $stmt->execute();
-    // URLで受け渡した、参加不参加情報をもとに絞り込み
-  } else {
-    $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE event_attendance.user_id = ? AND event_attendance.status = ? GROUP BY events.id ORDER BY events.start_at ASC");
-    $stmt->execute(array($user_id, $status));
-  }
-  // ステータスに値がない場合（未回答）event tableには存在するがevent_attendance tableにはないレコードを取得
+  $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE event_attendance.user_id = ? AND event_attendance.status = ? GROUP BY events.id ORDER BY events.start_at ASC");
+  $stmt->execute(array($user_id, $status));
 } else {
-  $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM event_attendance RIGHT OUTER JOIN events ON events.id = event_attendance.event_id WHERE event_attendance.status IS NULL GROUP BY events.id ORDER BY events.start_at ASC;");
-  $stmt->execute(array($_SESSION['user_id']));
+  $stmt = $db->query('SELECT events.id, events.name, events.start_at, events.end_at FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id GROUP BY events.id  ORDER BY start_at ASC');
+  $stmt->execute();
 }
 $events = $stmt->fetchAll();
-
-// ユーザーが管理者かを確認
-$stmt = $db->prepare('SELECT COUNT(id) FROM users WHERE is_admin = 1 AND id = ?');
-$stmt->execute(array($user_id));
-$is_admin = $stmt->fetch();
 
 function get_day_of_week($w)
 {
@@ -63,11 +49,6 @@ function get_day_of_week($w)
       -->
       <!-- ここにユーザーidを埋め込む -->
       <input type="hidden" name="user_id" value="<?= $_SESSION['user_id'] ?>">
-
-      <?php if ($is_admin[0] !== 0) { ?>
-        <a href="./admin.php" class="cursor-pointer p-2 text-sm text-white bg-blue-400 rounded-3xl bg-gradient-to-r from-blue-600 to-blue-300 flex items-center justify-center">管理画面へ</a>
-      <?php } ?>
-
     </div>
   </header>
 
@@ -77,18 +58,14 @@ function get_day_of_week($w)
       <div id="filter" class="mb-8">
         <h2 class="text-sm font-bold mb-3">フィルター</h2>
         <div class="flex">
-          <a href="./index.php?status=all" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white <?php if ($status == "all") {
-                                                                                                                    echo 'bg-blue-600 text-white';
-                                                                                                                  } ?>">全て</a>
-          <a href="./index.php?status=presence" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white <?php if ($status == "presence") {
-                                                                                                                        echo 'bg-blue-600 text-white';
-                                                                                                                      } ?>">参加</a>
-          <a href="./index.php?status=absence" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white <?php if ($status == "absence") {
-                                                                                                                        echo 'bg-blue-600 text-white';
-                                                                                                                      } ?>">不参加</a>
           <a href="./index.php" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white <?php if ($status == null) {
                                                                                                         echo 'bg-blue-600 text-white';
-                                                                                                      } ?>">未回答</a>
+                                                                                                      } ?>" id="filter_status_all">全て</a>
+          <a href="./index.php?status=presence" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white <?php if ($status == "presence") {
+                                                                                                                        echo 'bg-blue-600 text-white';
+                                                                                                                      } ?>" id="filter_status_presence">参加</a>
+          <!-- <a href="./index.php?status=absense" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">不参加</a>
+          <a href="./index.php" class="px-3 py-2 text-md font-bold mr-2 rounded-md shadow-md bg-white">未回答</a> -->
         </div>
       </div>
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -107,9 +107,8 @@ async function openModal(eventId) {
   });
 
 
-
   } catch (error) {
-    console.log(error)
+    console.log(error);
   }
   toggleModal()
 }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -102,6 +102,7 @@ async function openModal(eventId) {
       $('.accordion_click').click(function(){
           //クリックされた要素に隣接する要素が開いたり閉じたりする
           $(this).next('ul').slideToggle();
+          // モーダルが開くのを防止
           return false;
       });
   });

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -89,19 +89,6 @@ async function openModal(eventId) {
         break;
     }
     modalInnerHTML.insertAdjacentHTML('afterbegin', modalHTML)
-
-
-    // アコーディオン
-    $(function(){
-      //.accordion1の中のp要素がクリックされたら
-      $('.accordion a').click(function(){
-          //クリックされた.accordion1の中のp要素に隣接するul要素が開いたり閉じたりする。
-          $(this).next('ul').slideToggle();
-      });
-  });
-
-
-
   } catch (error) {
     console.log(error)
   }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -94,18 +94,21 @@ async function openModal(eventId) {
         `
         break;
     }
-    modalInnerHTML.insertAdjacentHTML('afterbegin', modalHTML)
 
 
     // アコーディオン
     $(function(){
-      $('.accordion_click').click(function(){
-          //クリックされた要素に隣接する要素が開いたり閉じたりする
-          $(this).next('ul').slideToggle();
-          // モーダルが開くのを防止
-          return false;
-      });
-  });
+        $('.accordion_click').click(function(){
+            //クリックされた要素に隣接する要素が開いたり閉じたりする
+            $(this).next('ul').slideToggle();
+            // モーダルが開くのを防止
+            return false;
+        });
+    });
+
+    modalInnerHTML.insertAdjacentHTML('afterbegin', modalHTML)
+
+
 
 
   } catch (error) {
@@ -113,18 +116,6 @@ async function openModal(eventId) {
   }
   toggleModal()
 }
-
-
-$(function () {
-  $('.js-menu__item__link_modal').each(function () {
-    $(this).on('click', function () {
-      $("+.submenu_modal", this).slideToggle();
-      $(".open-button_modal").toggleClass('change-direction');
-      $(".open-button_modal .chevron-wrapper_modal").toggleClass('participant-arrow');
-      return false;
-    });
-  });
-});
 
 function closeModal() {
   modalInnerHTML.innerHTML = ''

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -62,28 +62,34 @@ async function openModal(eventId) {
       case null:
         modalHTML += `
           <div class="text-center mt-6">
-            <!--
             <p class="text-lg font-bold text-yellow-400">未回答</p>
             <p class="text-xs text-yellow-400">期限 ${event.deadline}</p>
-            -->
           </div>
           <div class="flex mt-5">
-            <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" name="presence" value="presence" onclick="participateEvent(${eventId})">参加する</button>
+            <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" name="presence" value="presence" onclick="participateEvent(${eventId})">参加する</button>
             <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" name="absence" value="absence" onclick="nonParticipateEvent(${eventId})">参加しない</button>
           </div>
         `
         break;
-      case 1:
+      case 'presence':
+        modalHTML += `
+          <div class="text-center mt-10">
+            <p class="text-xl font-bold text-green-400">参加</p>
+          </div>
+          <div class="flex mt-5">
+            <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" disabled">参加する</button>
+            <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" name="absence" value="absence" onclick="nonParticipateEvent(${eventId})">参加しない</button>
+          </div>
+        `
+        break;
+      case 'absence':
         modalHTML += `
           <div class="text-center mt-10">
             <p class="text-xl font-bold text-gray-300">不参加</p>
           </div>
-        `
-        break;
-      case 2:
-        modalHTML += `
-          <div class="text-center mt-10">
-            <p class="text-xl font-bold text-green-400">参加</p>
+          <div class="flex mt-5">
+            <button class="flex-1 bg-gray-300 py-2 mx-3 rounded-3xl text-white text-lg font-bold" name="presence" value="presence" onclick="participateEvent(${eventId})">参加する</button>
+            <button class="flex-1 bg-blue-500 py-2 mx-3 rounded-3xl text-white text-lg font-bold" disabled>参加しない</button>
           </div>
         `
         break;
@@ -93,7 +99,9 @@ async function openModal(eventId) {
 
     // アコーディオン
     $(function(){
+      //.accordion1の中のp要素がクリックされたら
       $('.accordion a').click(function(){
+          //クリックされた.accordion1の中のp要素に隣接するul要素が開いたり閉じたりする。
           $(this).next('ul').slideToggle();
       });
   });
@@ -105,6 +113,18 @@ async function openModal(eventId) {
   }
   toggleModal()
 }
+
+
+$(function () {
+  $('.js-menu__item__link_modal').each(function () {
+    $(this).on('click', function () {
+      $("+.submenu_modal", this).slideToggle();
+      $(".open-button_modal").toggleClass('change-direction');
+      $(".open-button_modal .chevron-wrapper_modal").toggleClass('participant-arrow');
+      return false;
+    });
+  });
+});
 
 function closeModal() {
   modalInnerHTML.innerHTML = ''

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -38,17 +38,25 @@ async function openModal(eventId) {
       </p>
 
       <hr class="my-4">
-    `
-    modalHTML += `
+    
       <div class="accordion">
         <a class="accordion_click">
           <p class="text-sm"><span class="text-xl">${event.total_participants}</span>人参加 ></p>
         </a>
         <ul style="display: none">
-          <li>aaa</li>
+          <p class="font-bold">参加者一覧：</p>
+      `
+
+      for (let i = 0; i < event.participant_names.length; i++) {
+      modalHTML += `
+          <li>${event.participant_names[i][0]}</li>
+      `
+      }
+
+      modalHTML += `
         </ul>
       </div>
-    `
+      `
 
     switch (event.participation_status) {
       case null:

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -89,23 +89,22 @@ async function openModal(eventId) {
         break;
     }
     modalInnerHTML.insertAdjacentHTML('afterbegin', modalHTML)
+
+
+    // アコーディオン
+    $(function(){
+      $('.accordion a').click(function(){
+          $(this).next('ul').slideToggle();
+      });
+  });
+
+
+
   } catch (error) {
     console.log(error)
   }
   toggleModal()
 }
-
-
-$(function () {
-  $('.js-menu__item__link_modal').each(function () {
-    $(this).on('click', function () {
-      $("+.submenu_modal", this).slideToggle();
-      $(".open-button_modal").toggleClass('change-direction');
-      $(".open-button_modal .chevron-wrapper_modal").toggleClass('participant-arrow');
-      return false;
-    });
-  });
-});
 
 function closeModal() {
   modalInnerHTML.innerHTML = ''

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -38,9 +38,18 @@ async function openModal(eventId) {
       </p>
 
       <hr class="my-4">
-
-      <p class="text-sm"><span class="text-xl">${event.total_participants}</span>人参加 ></p>
     `
+    modalHTML += `
+      <div class="accordion">
+        <a class="accordion_click">
+          <p class="text-sm"><span class="text-xl">${event.total_participants}</span>人参加 ></p>
+        </a>
+        <ul style="display: none">
+          <li>aaa</li>
+        </ul>
+      </div>
+    `
+
     switch (event.participation_status) {
       case null:
         modalHTML += `
@@ -78,11 +87,36 @@ async function openModal(eventId) {
         break;
     }
     modalInnerHTML.insertAdjacentHTML('afterbegin', modalHTML)
+
+
+    // アコーディオン
+    $(function(){
+      //.accordion1の中のp要素がクリックされたら
+      $('.accordion a').click(function(){
+          //クリックされた.accordion1の中のp要素に隣接するul要素が開いたり閉じたりする。
+          $(this).next('ul').slideToggle();
+      });
+  });
+
+
+
   } catch (error) {
     console.log(error)
   }
   toggleModal()
 }
+
+
+$(function () {
+  $('.js-menu__item__link_modal').each(function () {
+    $(this).on('click', function () {
+      $("+.submenu_modal", this).slideToggle();
+      $(".open-button_modal").toggleClass('change-direction');
+      $(".open-button_modal .chevron-wrapper_modal").toggleClass('participant-arrow');
+      return false;
+    });
+  });
+});
 
 function closeModal() {
   modalInnerHTML.innerHTML = ''
@@ -108,7 +142,7 @@ async function participateEvent(eventId) {
       method: 'POST',
       body: formData
     }).then((res) => {
-      if(res.status !== 200) {
+      if (res.status !== 200) {
         throw new Error("system error");
       }
       return res.text();
@@ -133,7 +167,7 @@ async function nonParticipateEvent(eventId) {
       method: 'POST',
       body: formData
     }).then((res) => {
-      if(res.status !== 200) {
+      if (res.status !== 200) {
         throw new Error("system error");
       }
       return res.text();
@@ -144,4 +178,3 @@ async function nonParticipateEvent(eventId) {
     console.log(error)
   }
 }
-

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -99,10 +99,10 @@ async function openModal(eventId) {
 
     // アコーディオン
     $(function(){
-      //.accordion1の中のp要素がクリックされたら
-      $('.accordion a').click(function(){
-          //クリックされた.accordion1の中のp要素に隣接するul要素が開いたり閉じたりする。
+      $('.accordion_click').click(function(){
+          //クリックされた要素に隣接する要素が開いたり閉じたりする
           $(this).next('ul').slideToggle();
+          return false;
       });
   });
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -98,7 +98,7 @@ async function openModal(eventId) {
 
     // アコーディオン
     $(function(){
-        $('.accordion_click').click(function(){
+        $('.accordion_click').click(function(event){
             //クリックされた要素に隣接する要素が開いたり閉じたりする
             $(this).next('ul').slideToggle();
             // モーダルが開くのを防止


### PR DESCRIPTION
## 関連イシュー
#28 

### 終了条件
- [x] イベント詳細画面のイベント参加人数をクリックすると、アコーディオンで参加者の名前が一覧で表示される
- [x] 再度クリックすると閉じる

### 備考
- [x] トップページも同様に実装するとより良い（+1ビジネスポイント）

## 検証したこと
- [x] イベント詳細画面のイベント参加人数をクリックすると、アコーディオンで参加者の名前が一覧で表示される
- [x] 再度イベント詳細画面のイベント参加人数をクリックするとアコーディオンが閉じる
- [x] トップページのイベント参加人数をクリックすると、アコーディオンで参加者の名前が一覧で表示される
- [x] 再度トップページのイベント参加人数をクリックするとアコーディオンが閉じる

## エビデンス
ここから詳細画面⬇️
参加人数をクリックするとアコーディオンで一覧表示
<img width="321" alt="image" src="https://user-images.githubusercontent.com/86785032/189001935-66f80de1-f662-4f79-8f5e-e90f41dbe059.png">
再度押すと閉じる
<img width="324" alt="image" src="https://user-images.githubusercontent.com/86785032/189001963-05543944-a3be-49bf-af59-7d71ae2b6aa2.png">

ここからトップページ⬇️
参加人数をクリックするとアコーディオンで一覧表示
<img width="291" alt="image" src="https://user-images.githubusercontent.com/86785032/189002055-80f7f82b-e20f-4433-adc4-dc77f43e20f3.png">
再度押すと閉じる
<img width="296" alt="image" src="https://user-images.githubusercontent.com/86785032/189002068-740b177a-3c6b-4f84-ae64-9137e9eabfdd.png">

また、ユーザー3でログインしているが、以下より出欠情報も正しいことが確認できる
<img width="271" alt="image" src="https://user-images.githubusercontent.com/86785032/189002211-a1e889be-398e-4f44-8fec-8da12fc5f62b.png">


