### PR TITLE
#30 イベントの前日にメールで通知する （通知する先はユーザレコードの人すべて）

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -45,10 +45,10 @@ INSERT INTO events SET name='遊び', start_at='2021/09/22 18:00', end_at='2021/
 INSERT INTO events SET name='ハッカソン', start_at='2021/09/03 10:00', end_at='2021/09/03 22:00';
 INSERT INTO events SET name='遊び', start_at='2022/09/07 18:00', end_at='2022/09/07 22:00';
 INSERT INTO events SET name='スペモク', start_at='2022/09/08 18:00', end_at='2022/09/08 22:00';
-INSERT INTO events SET name='遊び', start_at='2022/09/09 18:00', end_at='2022/09/09 22:00';
-INSERT INTO events SET name='横モク', start_at='2022/09/10 18:00', end_at='2022/09/10 22:00';
-INSERT INTO events SET name='花火大会', start_at='2022/09/11 18:00', end_at='2022/09/11 22:00';
-INSERT INTO events SET name='スペモク', start_at='2022/09/12 18:00', end_at='2022/09/12 22:00';
+INSERT INTO events SET name='遊び', start_at='2022/09/09 18:00', end_at='2022/09/09 22:00', detail='みんなでいっぱい遊ぼうね！！何しよっか！！！';
+INSERT INTO events SET name='横モク', start_at='2022/09/10 18:00', end_at='2022/09/10 22:00', detail='横でもくもく！ハッカソンお疲れ様！';
+INSERT INTO events SET name='花火大会', start_at='2022/09/11 18:00', end_at='2022/09/11 22:00', detail='花火大会言ってないなああって思ったそこのあなた！一緒にいきましょ〜〜';
+INSERT INTO events SET name='映画', start_at='2022/09/12 18:00', end_at='2022/09/12 22:00', detail='みんなで久しぶりにmovie nightしたいなああ----';
 INSERT INTO events SET name='遊び', start_at='2022/09/13 18:00', end_at='2022/09/13 22:00';
 INSERT INTO events SET name='海', start_at='2022/09/14 18:00', end_at='2022/09/14 22:00';
 INSERT INTO events SET name='浅草', start_at='2022/09/15 18:00', end_at='2022/09/15 22:00';

--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -1,97 +1,282 @@
 DROP SCHEMA IF EXISTS posse;
+
 CREATE SCHEMA posse;
+
 USE posse;
 
 DROP TABLE IF EXISTS events;
-CREATE TABLE events (
-  id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
-  name VARCHAR(10) NOT NULL,
-  start_at DATETIME,
-  end_at DATETIME,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  deleted_at DATETIME
-);
+
+CREATE TABLE
+    events (
+        id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
+        name VARCHAR(10) NOT NULL,
+        start_at DATETIME,
+        end_at DATETIME,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        deleted_at DATETIME
+    );
 
 DROP TABLE IF EXISTS event_attendance;
-CREATE TABLE event_attendance (
-  id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
-  event_id INT NOT NULL,
-  user_id INT,
-  status VARCHAR(255),
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  deleted_at DATETIME
-);
 
+CREATE TABLE
+    event_attendance (
+        id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
+        event_id INT NOT NULL,
+        user_id INT,
+        status VARCHAR(255),
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        deleted_at DATETIME
+    );
 
-INSERT INTO events SET name='縦モク', start_at='2021/08/01 21:00', end_at='2021/08/01 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/02 21:00', end_at='2021/08/02 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/03 20:00', end_at='2021/08/03 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/08 21:00', end_at='2021/08/08 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/09 21:00', end_at='2021/08/09 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/10 20:00', end_at='2021/08/10 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/15 21:00', end_at='2021/08/15 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/16 21:00', end_at='2021/08/16 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/17 20:00', end_at='2021/08/17 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/22 21:00', end_at='2021/08/22 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/23 21:00', end_at='2021/08/23 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/24 20:00', end_at='2021/08/24 22:00';
-INSERT INTO events SET name='遊び', start_at='2021/09/22 18:00', end_at='2021/09/22 22:00';
-INSERT INTO events SET name='ハッカソン', start_at='2021/09/03 10:00', end_at='2021/09/03 22:00';
-INSERT INTO events SET name='遊び', start_at='2022/09/07 18:00', end_at='2022/09/06 22:00';
-INSERT INTO events SET name='スペモク', start_at='2022/09/08 18:00', end_at='2022/09/06 22:00';
-INSERT INTO events SET name='遊び', start_at='2022/09/09 18:00', end_at='2022/09/06 22:00';
-INSERT INTO events SET name='横モク', start_at='2022/09/10 18:00', end_at='2022/09/06 22:00';
-INSERT INTO events SET name='花火大会', start_at='2022/09/11 18:00', end_at='2022/09/06 22:00';
-INSERT INTO events SET name='スペモク', start_at='2022/09/12 18:00', end_at='2022/09/06 22:00';
-INSERT INTO events SET name='遊び', start_at='2022/09/13 18:00', end_at='2022/09/06 22:00';
-INSERT INTO events SET name='海', start_at='2022/09/14 18:00', end_at='2022/09/06 22:00';
-INSERT INTO events SET name='浅草', start_at='2022/09/15 18:00', end_at='2022/09/06 22:00';
-INSERT INTO events SET name='横モク', start_at='2022/09/16 18:00', end_at='2022/09/06 22:00';
-INSERT INTO event_attendance SET event_id=1, user_id = 1, status="presence";
-INSERT INTO event_attendance SET event_id=1, user_id = 1, status="presence";
-INSERT INTO event_attendance SET event_id=1, user_id = 1, status="presence";
-INSERT INTO event_attendance SET event_id=2, user_id = 1, status="presence";
-INSERT INTO event_attendance SET event_id=2, user_id = 1, status="presence";
-INSERT INTO event_attendance SET event_id=3, user_id = 1, status="presence";
+INSERT INTO events
+SET
+    name = '縦モク',
+    start_at = '2021/08/01 21:00',
+    end_at = '2021/08/01 23:00';
 
+INSERT INTO events
+SET
+    name = '横モク',
+    start_at = '2021/08/02 21:00',
+    end_at = '2021/08/02 23:00';
+
+INSERT INTO events
+SET
+    name = 'スペモク',
+    start_at = '2021/08/03 20:00',
+    end_at = '2021/08/03 22:00';
+
+INSERT INTO events
+SET
+    name = '縦モク',
+    start_at = '2021/08/08 21:00',
+    end_at = '2021/08/08 23:00';
+
+INSERT INTO events
+SET
+    name = '横モク',
+    start_at = '2021/08/09 21:00',
+    end_at = '2021/08/09 23:00';
+
+INSERT INTO events
+SET
+    name = 'スペモク',
+    start_at = '2021/08/10 20:00',
+    end_at = '2021/08/10 22:00';
+
+INSERT INTO events
+SET
+    name = '縦モク',
+    start_at = '2021/08/15 21:00',
+    end_at = '2021/08/15 23:00';
+
+INSERT INTO events
+SET
+    name = '横モク',
+    start_at = '2021/08/16 21:00',
+    end_at = '2021/08/16 23:00';
+
+INSERT INTO events
+SET
+    name = 'スペモク',
+    start_at = '2021/08/17 20:00',
+    end_at = '2021/08/17 22:00';
+
+INSERT INTO events
+SET
+    name = '縦モク',
+    start_at = '2021/08/22 21:00',
+    end_at = '2021/08/22 23:00';
+
+INSERT INTO events
+SET
+    name = '横モク',
+    start_at = '2021/08/23 21:00',
+    end_at = '2021/08/23 23:00';
+
+INSERT INTO events
+SET
+    name = 'スペモク',
+    start_at = '2021/08/24 20:00',
+    end_at = '2021/08/24 22:00';
+
+INSERT INTO events
+SET
+    name = '遊び',
+    start_at = '2021/09/22 18:00',
+    end_at = '2021/09/22 22:00';
+
+INSERT INTO events
+SET
+    name = 'ハッカソン',
+    start_at = '2021/09/03 10:00',
+    end_at = '2021/09/03 22:00';
+
+INSERT INTO events
+SET
+    name = '遊び',
+    start_at = '2022/09/07 18:00',
+    end_at = '2022/09/06 22:00';
+
+INSERT INTO events
+SET
+    name = 'スペモク',
+    start_at = '2022/09/08 18:00',
+    end_at = '2022/09/06 22:00';
+
+INSERT INTO events
+SET
+    name = '遊び',
+    start_at = '2022/09/09 18:00',
+    end_at = '2022/09/06 22:00';
+
+INSERT INTO events
+SET
+    name = '横モク',
+    start_at = '2022/09/10 18:00',
+    end_at = '2022/09/06 22:00';
+
+INSERT INTO events
+SET
+    name = '花火大会',
+    start_at = '2022/09/11 18:00',
+    end_at = '2022/09/06 22:00';
+
+INSERT INTO events
+SET
+    name = 'スペモク',
+    start_at = '2022/09/12 18:00',
+    end_at = '2022/09/06 22:00';
+
+INSERT INTO events
+SET
+    name = '遊び',
+    start_at = '2022/09/13 18:00',
+    end_at = '2022/09/06 22:00';
+
+INSERT INTO events
+SET
+    name = '海',
+    start_at = '2022/09/14 18:00',
+    end_at = '2022/09/06 22:00';
+
+INSERT INTO events
+SET
+    name = '浅草',
+    start_at = '2022/09/15 18:00',
+    end_at = '2022/09/06 22:00';
+
+INSERT INTO events
+SET
+    name = '横モク',
+    start_at = '2022/09/16 18:00',
+    end_at = '2022/09/06 22:00';
+
+INSERT INTO event_attendance
+SET
+    event_id = 1,
+    user_id = 1,
+    status = "presence";
+
+INSERT INTO event_attendance
+SET
+    event_id = 1,
+    user_id = 1,
+    status = "presence";
+
+INSERT INTO event_attendance
+SET
+    event_id = 1,
+    user_id = 1,
+    status = "presence";
+
+INSERT INTO event_attendance
+SET
+    event_id = 2,
+    user_id = 1,
+    status = "presence";
+
+INSERT INTO event_attendance
+SET
+    event_id = 2,
+    user_id = 1,
+    status = "presence";
+
+INSERT INTO event_attendance
+SET
+    event_id = 3,
+    user_id = 1,
+    status = "presence";
 
 -- ユーザーログイン
+
 DROP TABLE IF EXISTS users;
 
-CREATE TABLE users (
-  id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
-  email VARCHAR(255) NOT NULL,
-  password VARCHAR(255) NOT NULL,
-  is_admin TINYINT DEFAULT 0
-);
+CREATE TABLE
+    users (
+        id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
+        name VARCHAR(255) NOT NULL,
+        email VARCHAR(255) NOT NULL,
+        password VARCHAR(255) NOT NULL,
+        is_admin TINYINT DEFAULT 0
+    );
 
-INSERT INTO 
-  users 
+INSERT INTO users
 SET
-  email = "user@posse.com",
-  password = sha1('pass');
+    name = "こうへい.S.N",
+    email = "user@posse.com",
+    password = sha1('pass');
 
-INSERT INTO 
-  users 
+INSERT INTO users
 SET
-  email = "user2@posse.com",
-  password = sha1('pass');
+    name = "ももも",
+    email = "user2@posse.com",
+    password = sha1('pass');
+
+INSERT INTO users
+SET
+    name = "けんててててぃ", 
+    email = "user3@posse.com",
+    password = sha1('pass');
+
+INSERT INTO users
+SET
+    name = "きゃれん",
+    email = "user4@posse.com",
+    password = sha1('pass');
+
+INSERT INTO users
+SET
+    name = "れいち",
+    email = "user5@posse.com",
+    password = sha1('pass');
+
+INSERT INTO users
+SET
+    name = "なおち",
+    email = "user6@posse.com",
+    password = sha1('pass');
+
+INSERT INTO users
+SET
+    name = "てらち",
+    email = "user7@posse.com",
+    password = sha1('pass');
 
 -- パスワードリセット関連です。
 
 DROP TABLE IF EXISTS user_password_reset;
 
-CREATE TABLE user_password_reset (
-    id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
-    email VARCHAR(255) NOT NULL,
-    pass_token VARCHAR(255) NOT NULL,
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
+CREATE TABLE
+    user_password_reset (
+        id INT AUTO_INCREMENT NOT NULL PRIMARY KEY,
+        email VARCHAR(255) NOT NULL,
+        pass_token VARCHAR(255) NOT NULL,
+        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
 
-INSERT INTO
-    user_password_reset(email, pass_token);
-VALUES
-    ("test@test.com", "test");
+INSERT INTO user_password_reset(email, pass_token);
 
+VALUES ("test@test.com", "test");

--- a/src/index.php
+++ b/src/index.php
@@ -29,6 +29,10 @@ $events = $stmt->fetchAll();
 $stmt = $db->prepare('SELECT COUNT(id) FROM users WHERE is_admin = 1 AND id = ?');
 $stmt->execute(array($user_id));
 $is_admin = $stmt->fetch();
+// ログインしたuserの名前を取得
+$stmt_user_name = $db->prepare('SELECT name FROM users WHERE id = ?');
+$stmt_user_name->execute(array($user_id));
+$user_name = $stmt_user_name->fetch();
 
 function get_day_of_week($w)
 {
@@ -70,6 +74,7 @@ function get_day_of_week($w)
   </header>
 
   <main class="bg-gray-100">
+    <p class="p-3">ようこそ<?php echo $user_name['name'];?>さん！</p>
     <div class="w-full mx-auto p-5">
       <!-- イベント参加状況フィルターのボタン -->
       <div id="filter" class="mb-8">

--- a/src/remind_mail_1_all.php
+++ b/src/remind_mail_1_all.php
@@ -25,6 +25,8 @@ foreach ($tomorrow_events as $tomorrow_event) {
 foreach ($users as $user) {
 
 $user_name = $user['name'];
+$event_detail = $tomorrow_event['detail'];
+
 $to = $user_name;
 $tomorrow_event_name = $tomorrow_event['name'];
 $subject = <<<EOT
@@ -42,6 +44,8 @@ $body = <<<EOT
 {$user_name}のご参加、楽しみにしています！
 
 【イベント詳細】
+
+{$event_detail}
 
 EOT;
 

--- a/src/remind_mail_1_all.php
+++ b/src/remind_mail_1_all.php
@@ -24,7 +24,8 @@ $users = $stmt_user->fetchAll();
 foreach ($tomorrow_events as $tomorrow_event) {
 foreach ($users as $user) {
 
-$to = $user['email'];
+$user_name = $user['name'];
+$to = $user_name;
 $tomorrow_event_name = $tomorrow_event['name'];
 $subject = <<<EOT
     ${tomorrow_event_name}リマインドメール（前日 @全員）
@@ -32,13 +33,13 @@ $subject = <<<EOT
 $body = "明日はいよいよ${tomorrow_event_name}イベント当日となっています！";
 $headers = ["From"=>"system@posse-ap.com", "Content-Type"=>"text/plain; charset=UTF-8", "Content-Transfer-Encoding"=>"8bit"];
 
-$name = $user['name'];
 $event_date = $tomorrow_event['start_at'];
 $body = <<<EOT
-{$name}様
+{$user_name}様
 
 
 明日の ${event_date}より『${tomorrow_event_name}』を開催いたします！！！！
+{$user_name}のご参加、楽しみにしています！
 
 【イベント詳細】
 

--- a/src/remind_mail_1_all.php
+++ b/src/remind_mail_1_all.php
@@ -1,0 +1,50 @@
+<?php
+require('dbconnect.php');
+date_default_timezone_set('Asia/Tokyo');
+mb_language('ja');
+mb_internal_encoding('UTF-8');
+
+// 明日と明後日を取得
+$tomorrow_start  = date('Y-m-d 00:00:00',strtotime("+1 day"));
+$tomorrow_end  = date('Y-m-d 23:59:59',strtotime("+1 day"));
+
+echo $tomorrow_start;
+echo $tomorrow_end;
+
+// 明日中に行われるイベントのみを取得
+$stmt_event = $db->prepare("SELECT * FROM events where '$tomorrow_start' < start_at AND start_at < '$tomorrow_end'");
+$stmt_event->execute();
+$tomorrow_events = $stmt_event->fetchAll();
+
+// 全userを取得
+$stmt_user = $db->prepare("SELECT * FROM users");
+$stmt_user->execute();
+$users = $stmt_user->fetchAll();
+
+foreach ($tomorrow_events as $tomorrow_event) {
+foreach ($users as $user) {
+
+$to = $user['email'];
+$tomorrow_event_name = $tomorrow_event['name'];
+$subject = <<<EOT
+    ${tomorrow_event_name}リマインドメール（前日 @全員）
+    EOT;
+$body = "明日はいよいよ${tomorrow_event_name}イベント当日となっています！";
+$headers = ["From"=>"system@posse-ap.com", "Content-Type"=>"text/plain; charset=UTF-8", "Content-Transfer-Encoding"=>"8bit"];
+
+$name = $user['name'];
+$event_date = $tomorrow_event['start_at'];
+$body = <<<EOT
+{$name}様
+
+
+明日の ${event_date}より『${tomorrow_event_name}』を開催いたします！！！！
+
+【イベント詳細】
+
+EOT;
+
+mb_send_mail($to, $subject, $body, $headers);
+}
+}
+echo "メールを送信しました";


### PR DESCRIPTION
## 関連イシュー
#30 

### 終了条件

- [x] バッチを実行すると処理日がイベントの前日の場合メールを送付する
- [x] メールの宛先はユーザレコードの人全て
- [x] メールにはイベント名、内容、開催日時を記載する

## 検証したこと

- [x] ターミナル上にて　`php remind_mail_1_all.php`（メール処理を記述しているファイル）
とコマンドを打つと、mailhogにメールが送信されること

- [x] メールの内容にイベント名、内容、開催日時が記載されていること

- [x] 開催日前日のイベントのみメールが送信されていること

- [x] 全てのuserにメールが送信されていること


## エビデンス

### ⏬ ターミナルで php remind_mail_1_all.phpのコマンドを打つとメールが送信される

<img width="481" alt="スクリーンショット 2022-09-08 6 46 03" src="https://user-images.githubusercontent.com/86845003/188988767-61fd5d9c-f81a-4823-9566-1038ff456ecf.png">

### ⏬ mailhogにて全員にメールが送信されたことを確認

<img width="1380" alt="スクリーンショット 2022-09-08 6 46 26" src="https://user-images.githubusercontent.com/86845003/188988851-8306fce9-017d-49ab-835f-9904d56e5b9d.png">

### ⏬ メールの内容を確認（イベント名、内容、開催日時、氏名を記載）

<img width="750" alt="スクリーンショット 2022-09-08 12 37 09" src="https://user-images.githubusercontent.com/86845003/189028648-621960b0-b678-404c-94eb-0832f2dc9418.png">