### PR TITLE
#31 イベントの前日にメールで通知する（通知する先は参加としている人のみ）

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -21,7 +21,7 @@ if (isset($status)) {
   // ステータスに値がない場合（未回答）event tableには存在するがevent_attendance tableにはないレコードを取得
 } else {
   $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM event_attendance RIGHT OUTER JOIN events ON events.id = event_attendance.event_id WHERE event_attendance.status IS NULL GROUP BY events.id ORDER BY events.start_at ASC;");
-  $stmt->execute(array($_SESSION['user_id']));
+  $stmt->execute(array($user_id));
 }
 $events = $stmt->fetchAll();
 
@@ -74,7 +74,7 @@ function get_day_of_week($w)
   </header>
 
   <main class="bg-gray-100">
-    <p class="p-3">ようこそ<?php echo $user_name['name'];?>さん！</p>
+    <p class="p-3">ようこそ<?php echo $user_name['name']; ?>さん！</p>
     <div class="w-full mx-auto p-5">
       <!-- イベント参加状況フィルターのボタン -->
       <div id="filter" class="mb-8">

--- a/src/remind_mail_1_all.php
+++ b/src/remind_mail_1_all.php
@@ -4,9 +4,9 @@ date_default_timezone_set('Asia/Tokyo');
 mb_language('ja');
 mb_internal_encoding('UTF-8');
 
-// 明日と明後日を取得
-$tomorrow_start  = date('Y-m-d 00:00:00',strtotime("+1 day"));
-$tomorrow_end  = date('Y-m-d 23:59:59',strtotime("+1 day"));
+// 明日の始まりと終わり
+$tomorrow_start  = date('Y-m-d 00:00:00', strtotime("+1 day"));
+$tomorrow_end  = date('Y-m-d 23:59:59', strtotime("+1 day"));
 
 echo $tomorrow_start;
 echo $tomorrow_end;
@@ -22,30 +22,28 @@ $stmt_user->execute();
 $users = $stmt_user->fetchAll();
 
 foreach ($tomorrow_events as $tomorrow_event) {
-foreach ($users as $user) {
+    foreach ($users as $user) {
 
-$user_name = $user['name'];
-$to = $user_name;
-$tomorrow_event_name = $tomorrow_event['name'];
-$subject = <<<EOT
-    ${tomorrow_event_name}リマインドメール（前日 @全員）
+        $user_name = $user['name'];
+        $to = $user_name;
+        $tomorrow_event_name = $tomorrow_event['name'];
+        $subject = <<<EOT
+        『${tomorrow_event_name}』リマインドメール（前日 @全員）
+        EOT;
+        $body = "明日はいよいよ${tomorrow_event_name}イベント当日となっています！";
+        $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
+
+        $event_date = $tomorrow_event['start_at'];
+        $body = <<<EOT
+    {$user_name}様
+
+    明日の ${event_date}より『${tomorrow_event_name}』を開催いたします！！！！
+    {$user_name}さんのご参加、楽しみにしています！
+
+    【イベント詳細】
+
     EOT;
-$body = "明日はいよいよ${tomorrow_event_name}イベント当日となっています！";
-$headers = ["From"=>"system@posse-ap.com", "Content-Type"=>"text/plain; charset=UTF-8", "Content-Transfer-Encoding"=>"8bit"];
-
-$event_date = $tomorrow_event['start_at'];
-$body = <<<EOT
-{$user_name}様
-
-
-明日の ${event_date}より『${tomorrow_event_name}』を開催いたします！！！！
-{$user_name}のご参加、楽しみにしています！
-
-【イベント詳細】
-
-EOT;
-
-mb_send_mail($to, $subject, $body, $headers);
-}
+        mb_send_mail($to, $subject, $body, $headers);
+    }
 }
 echo "メールを送信しました";

--- a/src/remind_mail_1_participants.php
+++ b/src/remind_mail_1_participants.php
@@ -7,14 +7,14 @@ date_default_timezone_set('Asia/Tokyo');
 mb_language('ja');
 mb_internal_encoding('UTF-8');
 
-// ３日後の始まりと終わりを取得
-$three_days_later_start  = date('Y-m-d 00:00:00', strtotime("+1 day"));
-$three_days_later_end  = date('Y-m-d 23:59:59', strtotime("+1 day"));
+// 明日の始まりと終わり
+$tomorrow_start  = date('Y-m-d 00:00:00', strtotime("+1 day"));
+$tomorrow_end  = date('Y-m-d 23:59:59', strtotime("+1 day"));
 
 // ３日後中に行われるイベントのみを取得 同時にuserにおいて、statusがpresence（参加）となってる人のみ取得
 $stmt = $db->prepare("SELECT * FROM events JOIN event_attendance ON event_attendance.event_id = events.id LEFT JOIN users ON event_attendance.user_id = users.id
-WHERE '$three_days_later_start' < events.start_at 
-AND events.start_at < '$three_days_later_end' 
+WHERE '$tomorrow_start' < events.start_at 
+AND events.start_at < '$tomorrow_end' 
 AND event_attendance.status = 'presence'
 ");
 $stmt->execute();
@@ -24,26 +24,32 @@ foreach ($participants as $participant) {
 
     $to = $participant['email'];
     $user_name = $participant['name'];
-    $three_days_later_event_name = $participant[1];
+    $event_detail = $tomorrow_event['detail'];
+
+
+    $tomorrow_event_name = $participant[1];
     $subject = <<<EOT
-            『${three_days_later_event_name}』リマインドメール（前日 @参加者）
+            『${tomorrow_event_name}』リマインドメール（前日 @参加者）
             EOT;
     $body = "本文";
     $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
 
     $participant_name = $participant['name'];
     $three_days_later_date = $participant['start_at'];
-    $detail = $participant['detail'];
+    $event_detail = $participant['detail'];
+
     $body = <<<EOT
     {$participant_name}さん
-    参加予定の「${three_days_later_event_name}」の前日となりました。
+    参加予定の「${tomorrow_event_name}」の前日となりました。
     ${three_days_later_date}に始まります！
 
     参加予定の方にのみ連絡を差し上げています。
-    明日の ${event_date}より『${three_days_later_event_name}』を開催いたします！
+    明日の ${event_date}より『${tomorrow_event_name}』を開催いたします！
     {$user_name}さんのご参加、楽しみにしています！
 
     【イベント詳細】
+
+    {$event_detail}
 
     EOT;
 

--- a/src/remind_mail_1_participants.php
+++ b/src/remind_mail_1_participants.php
@@ -1,0 +1,55 @@
+
+
+<?php
+require('dbconnect.php');
+
+date_default_timezone_set('Asia/Tokyo');
+mb_language('ja');
+mb_internal_encoding('UTF-8');
+
+// ３日後の始まりと終わりを取得
+$three_days_later_start  = date('Y-m-d 00:00:00', strtotime("+1 day"));
+$three_days_later_end  = date('Y-m-d 23:59:59', strtotime("+1 day"));
+
+// ３日後中に行われるイベントのみを取得 同時にuserにおいて、statusがpresence（参加）となってる人のみ取得
+$stmt = $db->prepare("SELECT * FROM events JOIN event_attendance ON event_attendance.event_id = events.id LEFT JOIN users ON event_attendance.user_id = users.id
+WHERE '$three_days_later_start' < events.start_at 
+AND events.start_at < '$three_days_later_end' 
+AND event_attendance.status = 'presence'
+");
+$stmt->execute();
+$participants = $stmt->fetchAll();
+
+foreach ($participants as $participant) {
+
+    var_dump($participant[1]);
+
+    $to = $participant['email'];
+    $user_name = $participant['name'];
+    $three_days_later_event_name = $participant[1];
+    $subject = <<<EOT
+            『${three_days_later_event_name}』リマインドメール（前日 @参加者）
+            EOT;
+    $body = "本文";
+    $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];
+
+    $participant_name = $participant['name'];
+    $three_days_later_date = $participant['start_at'];
+    $detail = $participant['detail'];
+    $body = <<<EOT
+    {$participant_name}さん
+    参加予定の「${three_days_later_event_name}」の前日となりました。
+    ${three_days_later_date}に始まります！
+
+    参加予定の方にのみ連絡を差し上げています。
+    明日の ${event_date}より『${three_days_later_event_name}』を開催いたします！
+    {$user_name}さんのご参加、楽しみにしています！
+
+    【イベント詳細】
+
+    EOT;
+
+    mb_send_mail($to, $subject, $body, $headers);
+}
+
+echo "メールを送信しました";

--- a/src/remind_mail_1_participants.php
+++ b/src/remind_mail_1_participants.php
@@ -22,8 +22,6 @@ $participants = $stmt->fetchAll();
 
 foreach ($participants as $participant) {
 
-    var_dump($participant[1]);
-
     $to = $participant['email'];
     $user_name = $participant['name'];
     $three_days_later_event_name = $participant[1];


### PR DESCRIPTION
## 関連イシュー
#31 

### 終了条件

- [x] バッチを実行すると処理日がイベントの前日の場合メールを送付する
- [x] メールの宛先は参加としている人のみ
- [x] メールにはイベント名、内容、開催日時を記載する

## 検証したこと

- [x] ターミナル上にて　`php remind_mail_1_participants.php`（メール処理を記述しているファイル）
とコマンドを打つと、mailhogにメールが送信されること

- [x] メールの内容にイベント名、内容、開催日時が記載されていること

- [x]  開催日前日のイベントのみメールが送信されていること

- [x] 参加予定者のみにメールが送信されていること

## エビデンス

明日のイベントの「遊び」（event_idは17）に参加するのはこの二人である。
ユーザー画面での表示
<img width="342" alt="image" src="https://user-images.githubusercontent.com/94669039/189098050-2f6f7d1b-ca51-4a69-8cbb-aeb731d55f1d.png">
event_attendance テーブル
<img width="330" alt="image" src="https://user-images.githubusercontent.com/94669039/189098223-834b6895-d11f-4632-a5ca-ff59c6b70e09.png">
※userテーブルでメールが送信されるべきユーザーを参照する
<img width="408" alt="image" src="https://user-images.githubusercontent.com/94669039/189098342-111d5877-ea4f-4790-8e3b-6423a32228da.png">

⏬ ターミナルで `php remind_mail_1_participants.php`のコマンドを打つとメールが送信される

<img width="438" alt="スクリーンショット 2022-09-08 10 27 28" src="https://user-images.githubusercontent.com/86845003/189013279-9d28d058-dc05-4871-9166-8a987c16b446.png">

⏬ mailhogにて参加予定者にのみメールが送信されたことを確認

<img width="1006" alt="image" src="https://user-images.githubusercontent.com/94669039/189098994-43675ee0-dcf4-490b-a4a9-c47d88de3316.png">

⏬ メールの内容を確認（詳細まだだよ〜）

<img width="676" alt="image" src="https://user-images.githubusercontent.com/94669039/189099151-e8aff65a-344b-432d-9147-c8d7018b1b39.png">
<img width="679" alt="image" src="https://user-images.githubusercontent.com/94669039/189099221-211f3710-f1c4-4485-b191-31513d7eed21.png">

