### PR TITLE
#5 イベント一覧 Issue5 ページング / 追加・修正あります。

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -49,6 +49,16 @@ INSERT INTO events SET name='遊び', start_at='2022/09/13 18:00', end_at='2022/
 INSERT INTO events SET name='海', start_at='2022/09/14 18:00', end_at='2022/09/06 22:00';
 INSERT INTO events SET name='浅草', start_at='2022/09/15 18:00', end_at='2022/09/06 22:00';
 INSERT INTO events SET name='横モク', start_at='2022/09/16 18:00', end_at='2022/09/06 22:00';
+INSERT INTO events SET name='コミもく', start_at='2022/09/17 18:00', end_at='2022/09/06 22:00';
+INSERT INTO events SET name='posseLab会', start_at='2022/09/18 18:00', end_at='2022/09/06 22:00';
+INSERT INTO events SET name='たわーtoタワー', start_at='2022/09/19 18:00', end_at='2022/09/06 22:00';
+INSERT INTO events SET name='池to海', start_at='2022/09/20 18:00', end_at='2022/09/06 22:00';
+INSERT INTO events SET name='語る会', start_at='2022/09/21 18:00', end_at='2022/09/06 22:00';
+INSERT INTO events SET name='睡眠もくもく会', start_at='2022/09/22 18:00', end_at='2022/09/06 22:00';
+INSERT INTO events SET name='ありがとうの会', start_at='2022/09/23 18:00', end_at='2022/09/06 22:00';
+
+
+
 INSERT INTO event_attendance SET event_id=1, user_id = 1, status="presence";
 INSERT INTO event_attendance SET event_id=1, user_id = 1, status="presence";
 INSERT INTO event_attendance SET event_id=1, user_id = 1, status="presence";

--- a/src/index.php
+++ b/src/index.php
@@ -81,48 +81,21 @@ function get_day_of_week($w)
         </div>
       </div>
 
-      <!-- ページング関係 表示されるべきイベントを数えて$countに入る。-->
+      <!-- ページング関係 -->
       <?php
-      $count = 0;
-      $today_time = strtotime("today");
-      foreach ($events as $event) :
-        $event_start = strtotime($event['start_at']);
-        if ($today_time <= $event_start) {
-          $count++;
-        } else {
-          continue;
-        }
-      endforeach;
-      echo $count;
-      ?>
-      <?php
-
-      // $books_numは$countに置き換える。
-
       define('MAX', '10'); // 1ページの記事の表示数
+      $count = count($events);
       $max_page = ceil($count / MAX); // トータルページ数
       if (!isset($_GET['page_id'])) { // $_GET['page_id'] はURLに渡された現在のページ数
         $now = 1; // 設定されてない場合は1ページ目にする
       } else {
         $now = $_GET['page_id'];
       }
-
       $start_no = ($now - 1) * MAX; // 配列の何番目から取得すればよいか
       // array_sliceは、配列の何番目($start_no)から何番目(MAX)まで切り取る関数
       $disp_data = array_slice($events, $start_no, MAX, true);
-
-      // var_dump($events);
-      var_dump($disp_data);
-      // foreach ($disp_data as $val) { // データ表示
-      //   echo $val['book_kind'] . '　' . $val['book_name'] . '<br />';
-      // }
-      // 上の３ぎょうは下のほうほforeachです。
-
-
+      // ＄disp_dataは要素数が各ページの要素数の配列（ページごとに生成される。）
       ?>
-
-
-
 
       <!-- 各イベントカード -->
       <div id="events-list">
@@ -131,17 +104,10 @@ function get_day_of_week($w)
         </div>
         <?php 
           foreach ($disp_data as $event) : 
-          // foreach ($disp_data as $event) : ?>
-          <?php
           $start_date = strtotime($event['start_at']);
           $end_date = strtotime($event['end_at']);
           $day_of_week = get_day_of_week(date("w", $start_date));
           $today = strtotime("today");
-
-          // strtotimeで今日の0:00を取得 start_dateがそれより前であれば、continueで処理をスキップ
-          if ($start_date < $today) {
-            continue;
-          };
           ?>
 
           <!-- ここから単体のイベント -->
@@ -175,22 +141,22 @@ function get_day_of_week($w)
           </div>
         <?php endforeach; ?>
       </div>
-      <div>
+
+
+      <div class="flex justify-evenly">
         <?php
         for ($i = 1; $i <= $max_page; $i++) { // 最大ページ数分リンクを作成
-          if ($i == $now) { // 現在表示中のページ数の場合はリンクを貼らない
-            echo $now . ' ';
-
+          if ($i == $now) { // 現在表示中のページ数の場合はaタグではなくただの文字
+            // echo $now . ' ';
+            $now_html = "<p>$now</p>";
+            echo $now_html;
           } else {
-
             $page_link_ref = "/index.php?page_id=$i";
-            $page_link_html = "<a href='$page_link_ref'>$i</a>";
+            $page_link_html = "<p><a href='$page_link_ref'>$i</a></p>";
             echo $page_link_html;
-
           }
         }
         ?>
-
       </div>
     </div>
   </main>

--- a/src/index.php
+++ b/src/index.php
@@ -80,6 +80,14 @@ function get_day_of_week($w)
         </div>
       </div>
 
+<!-- ページング関係 -->
+      <?php
+        $count_sql = 'SELECT count(*) FROM events WHERE start_at = ? ';
+        $stmt = $db->prepare($count_sql);
+        $stmt->execute(array($));
+        $result = $stmt->fetch();
+      ?>
+
       <!-- 各イベントカード -->
       <div id="events-list">
         <div class="flex justify-between items-center mb-3">

--- a/src/index.php
+++ b/src/index.php
@@ -92,12 +92,13 @@ function get_day_of_week($w)
           $day_of_week = get_day_of_week(date("w", $start_date));
           $today = strtotime("today");
 
-          // strtotimeで今日の0:00を取得 star_dateがそれより前であれば、continueで処理をスキップ
+          // strtotimeで今日の0:00を取得 start_dateがそれより前であれば、continueで処理をスキップ
           if ($start_date < $today) {
             continue;
           };
           ?>
 
+          <!-- ここから単体のイベント -->
           <div class="modal-open bg-white mb-3 p-4 flex justify-between rounded-md shadow-md cursor-pointer" id="event-<?php echo $event['id']; ?>">
             <div>
               <h3 class="font-bold text-lg mb-2"><?php echo $event['name'] ?></h3>

--- a/src/index.php
+++ b/src/index.php
@@ -80,27 +80,46 @@ function get_day_of_week($w)
         </div>
       </div>
 
-      <!-- ページング関係 -->
+      <!-- ページング関係 表示されるべきイベントを数えて$countに入る。-->
       <?php
-      
-      $count_sql = 'SELECT count(*) FROM events WHERE start_at < ? ';
-      $stmt = $db->prepare($count_sql);
-      $stmt->execute(array(今日の秒数));
-      $result = $stmt->fetch();
-
-
-      // foreach ($events as $event) :
-      //   $event_start = strtotime($event['start_at']);
-      //   echo $event_start;
-      //   $count_sql = 'SELECT count(*) FROM events WHERE start_at < ? ';
-      //   $stmt = $db->prepare($count_sql);
-      //   $stmt->execute(array());
-      //   $result = $stmt->fetch();
-      // endforeach; ?>
-
-      <?php
-      echo $result;
+      $count = 0;
+      $today_time = strtotime("today");
+      foreach ($events as $event) :
+        $event_start = strtotime($event['start_at']);
+        if ($today_time <= $event_start) {
+          $count++;
+        } else {
+          continue;
+        }
+      endforeach;
+      echo $count;
       ?>
+      <?php
+
+      // $books_numは$countに置き換える。
+
+      define('MAX', '10'); // 1ページの記事の表示数
+      $max_page = ceil($books_num / MAX); // トータルページ数
+      if (!isset($_GET['page_id'])) { // $_GET['page_id'] はURLに渡された現在のページ数
+        $now = 1; // 設定されてない場合は1ページ目にする
+      } else {
+        $now = $_GET['page_id'];
+      }
+      $start_no = ($now - 1) * MAX; // 配列の何番目から取得すればよいか
+      // array_sliceは、配列の何番目($start_no)から何番目(MAX)まで切り取る関数
+      $disp_data = array_slice($events, $start_no, MAX, true);
+
+      
+
+      // foreach ($disp_data as $val) { // データ表示
+      //   echo $val['book_kind'] . '　' . $val['book_name'] . '<br />';
+      // }
+      // 上の３ぎょうは下のほうほforeachです。
+
+
+      ?>
+
+
 
 
       <!-- 各イベントカード -->
@@ -151,6 +170,22 @@ function get_day_of_week($w)
             </div>
           </div>
         <?php endforeach; ?>
+      </div>
+      <div>
+        <?php
+        for ($i = 1; $i <= $max_page; $i++) { // 最大ページ数分リンクを作成
+          if ($i == $now) { // 現在表示中のページ数の場合はリンクを貼らない
+            echo $now . ' ';
+            echo "<p class=>aaaaaa</p>";
+
+          } else {
+
+            // $page_link_ref = "/test.php?page_id=";
+            // $page_link_html = "<a href='$page_link_ref. $i'> . $i . '</a>' . ' ' ";
+            // echo $page_link_html;
+          }
+        }
+        ?>
       </div>
     </div>
   </main>

--- a/src/index.php
+++ b/src/index.php
@@ -109,8 +109,7 @@ function get_day_of_week($w)
       // array_sliceは、配列の何番目($start_no)から何番目(MAX)まで切り取る関数
       $disp_data = array_slice($events, $start_no, MAX, true);
 
-      
-
+      var_dump($disp_data);
       // foreach ($disp_data as $val) { // データ表示
       //   echo $val['book_kind'] . '　' . $val['book_name'] . '<br />';
       // }
@@ -127,7 +126,9 @@ function get_day_of_week($w)
         <div class="flex justify-between items-center mb-3">
           <h2 class="text-sm font-bold">一覧</h2>
         </div>
-        <?php foreach ($events as $event) : ?>
+        <?php 
+          // foreach ($events as $event) : 
+          foreach ($disp_data as $event) : ?>
           <?php
           $start_date = strtotime($event['start_at']);
           $end_date = strtotime($event['end_at']);
@@ -183,9 +184,12 @@ function get_day_of_week($w)
             // $page_link_ref = "/test.php?page_id=";
             // $page_link_html = "<a href='$page_link_ref. $i'> . $i . '</a>' . ' ' ";
             // echo $page_link_html;
+            echo "<p class=>aaaaaa</p>";
+
           }
         }
         ?>
+
       </div>
     </div>
   </main>
@@ -209,5 +213,3 @@ function get_day_of_week($w)
 
   <script src="/js/main.js"></script>
 </body>
-
-</html>

--- a/src/index.php
+++ b/src/index.php
@@ -105,11 +105,13 @@ function get_day_of_week($w)
       } else {
         $now = $_GET['page_id'];
       }
+
       $start_no = ($now - 1) * MAX; // 配列の何番目から取得すればよいか
       // array_sliceは、配列の何番目($start_no)から何番目(MAX)まで切り取る関数
-      $disp_data = array_slice($events, $start_no, MAX, true);
+      // $disp_data = array_slice($events, $start_no, MAX, true);
 
-      var_dump($disp_data);
+      // var_dump($events);
+      // var_dump($disp_data);
       // foreach ($disp_data as $val) { // データ表示
       //   echo $val['book_kind'] . '　' . $val['book_name'] . '<br />';
       // }
@@ -127,8 +129,8 @@ function get_day_of_week($w)
           <h2 class="text-sm font-bold">一覧</h2>
         </div>
         <?php 
-          // foreach ($events as $event) : 
-          foreach ($disp_data as $event) : ?>
+          foreach ($events as $event) : 
+          // foreach ($disp_data as $event) : ?>
           <?php
           $start_date = strtotime($event['start_at']);
           $end_date = strtotime($event['end_at']);

--- a/src/index.php
+++ b/src/index.php
@@ -80,13 +80,28 @@ function get_day_of_week($w)
         </div>
       </div>
 
-<!-- ページング関係 -->
+      <!-- ページング関係 -->
       <?php
-        $count_sql = 'SELECT count(*) FROM events WHERE start_at = ? ';
-        $stmt = $db->prepare($count_sql);
-        $stmt->execute(array($));
-        $result = $stmt->fetch();
+      
+      $count_sql = 'SELECT count(*) FROM events WHERE start_at < ? ';
+      $stmt = $db->prepare($count_sql);
+      $stmt->execute(array(今日の秒数));
+      $result = $stmt->fetch();
+
+
+      // foreach ($events as $event) :
+      //   $event_start = strtotime($event['start_at']);
+      //   echo $event_start;
+      //   $count_sql = 'SELECT count(*) FROM events WHERE start_at < ? ';
+      //   $stmt = $db->prepare($count_sql);
+      //   $stmt->execute(array());
+      //   $result = $stmt->fetch();
+      // endforeach; ?>
+
+      <?php
+      echo $result;
       ?>
+
 
       <!-- 各イベントカード -->
       <div id="events-list">


### PR DESCRIPTION
## 関連イシュー
#5 
## 関連プルリクエスト
https://github.com/posse-ap/posse2-hackathon-202209-team2A/pull/73 
こちらで足りていなかったところを実装しています。お手数ですがご確認お願いします。

### 終了条件

- [x] 画面下部にページャーを表示
- [x] 1ページに10イベントまで表示

### 備考

ページングと無限スクロールはどちらかを選択
→ページングを選択

## 検証したこと

- [x] 1ページあたり、イベント10件まで表示。
- [x] ページの一番下に、ページを選択するボタン（ページャー）を設置。
- [x] 現在いるページの数字が書かれたボタンは、pタグで囲まれているので押せない。
- [x] 他のページの数字が書かれたボタンについては、aタグでも囲まれており、押すとその数字のページに移動する。

（関係ないとは思いますが）
- [x] ページ移動先でも参加・不参加ボタンが正常に動作すること
- [x] リマインドメールが全て正常に送信できること

## エビデンス

**1ページ目、10件表示**
1ページ目上の方
<img width="339" alt="image" src="https://user-images.githubusercontent.com/94669039/189067086-2a9ff15c-79df-4a61-94fe-7e6e5efc6925.png">
１ページ目下の方
<img width="342" alt="image" src="https://user-images.githubusercontent.com/94669039/189067168-431f5752-916a-4da7-aa98-b6d6e423757a.png">

**2ページ目、6件表示**
２ページ目上の方
<img width="337" alt="image" src="https://user-images.githubusercontent.com/94669039/189067305-c7db589b-eef8-4a15-b22b-2c216a982dbf.png">
<img width="340" alt="image" src="https://user-images.githubusercontent.com/94669039/189067413-2b59cc13-c6d7-4445-8e7d-6cbbf2246967.png">
２ページ目下の方