### PR TITLE
#29 SQL参加答者一覧を出力する

### DIFF
--- a/mysql/sql/init.sql
+++ b/mysql/sql/init.sql
@@ -28,21 +28,7 @@ CREATE TABLE event_attendance (
   deleted_at DATETIME
 );
 
-
-INSERT INTO events SET name='縦モク', start_at='2021/08/01 21:00', end_at='2021/08/01 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/02 21:00', end_at='2021/08/02 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/03 20:00', end_at='2021/08/03 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/08 21:00', end_at='2021/08/08 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/09 21:00', end_at='2021/08/09 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/10 20:00', end_at='2021/08/10 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/15 21:00', end_at='2021/08/15 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/16 21:00', end_at='2021/08/16 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/17 20:00', end_at='2021/08/17 22:00';
-INSERT INTO events SET name='縦モク', start_at='2021/08/22 21:00', end_at='2021/08/22 23:00';
-INSERT INTO events SET name='横モク', start_at='2021/08/23 21:00', end_at='2021/08/23 23:00';
-INSERT INTO events SET name='スペモク', start_at='2021/08/24 20:00', end_at='2021/08/24 22:00';
-INSERT INTO events SET name='遊び', start_at='2021/09/22 18:00', end_at='2021/09/22 22:00';
-INSERT INTO events SET name='ハッカソン', start_at='2021/09/03 10:00', end_at='2021/09/03 22:00';
+INSERT INTO events SET name='ハッカソン', start_at='2022/09/08 10:00', end_at='2022/09/03 22:00';
 INSERT INTO events SET name='遊び', start_at='2022/09/07 18:00', end_at='2022/09/07 22:00';
 INSERT INTO events SET name='スペモク', start_at='2022/09/08 18:00', end_at='2022/09/08 22:00';
 INSERT INTO events SET name='遊び', start_at='2022/09/09 18:00', end_at='2022/09/09 22:00', detail='みんなでいっぱい遊ぼうね！！何しよっか！！！';

--- a/src/index.php
+++ b/src/index.php
@@ -10,17 +10,17 @@ $date = date("y-m-d H:i:s");
 
 if (isset($status)) {
   if ($status == 'all') {
-    $stmt = $db->prepare('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.start_at >= ? GROUP BY events.id ORDER BY start_at ASC');
-    $stmt->execute(array($date));
+    $stmt = $db->prepare('SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE events.start_at >= CURDATE() GROUP BY events.id ORDER BY start_at ASC');
+    $stmt->execute();
     // URLで受け渡した、参加不参加情報をもとに絞り込み
   } else {
-    $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE event_attendance.user_id = ? AND event_attendance.status = ? AND events.start_at >= ? GROUP BY events.id ORDER BY events.start_at ASC");
-    $stmt->execute(array($user_id, $status, $date));
+    $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM events LEFT JOIN event_attendance ON events.id = event_attendance.event_id WHERE event_attendance.user_id = ? AND event_attendance.status = ? AND events.start_at >= CURDATE() GROUP BY events.id ORDER BY events.start_at ASC");
+    $stmt->execute(array($user_id, $status));
   }
   // ステータスに値がない場合（未回答）event tableには存在するがevent_attendance tableにはないレコードを取得
 } else {
-  $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM event_attendance RIGHT OUTER JOIN events ON events.id = event_attendance.event_id WHERE event_attendance.status IS NULL AND events.start_at >= ? GROUP BY events.id ORDER BY events.start_at ASC;");
-  $stmt->execute(array($date));
+  $stmt = $db->prepare("SELECT events.id, events.name, events.start_at, events.end_at, count(event_attendance.id) AS total_participants FROM event_attendance RIGHT OUTER JOIN events ON events.id = event_attendance.event_id WHERE event_attendance.status IS NULL AND events.start_at >= CURDATE() GROUP BY events.id ORDER BY events.start_at ASC;");
+  $stmt->execute();
 }
 $events = $stmt->fetchAll();
 


### PR DESCRIPTION
## 関連イシュー
#29 （プルリクを作成するためのブランチ）

#### 終了条件

- [x] どのイベントに誰が参加するのか確認できる
- [x] 1回のSQLで処理日以降に開催される全てのイベントの情報が取得できる

■出力のイメージ（SQL結果に以下の情報が含まれていればOKです。ヘッダー、フッター書式は特に問いません）
Aイベント　1999/01/01　信田健児
Aイベント　1999/01/01　橋本満
Bイベント　1999/01/01　信田健児
Bイベント　1999/01/01　橋本満

駄目な例
※イベントでソートされていないので、Bイベントの未回答が誰かの確認が大変
Aイベント　1999/01/01　信田健児
Bイベント　1999/01/01　信田健児
Aイベント　1999/01/01　橋本満
Bイベント　1999/01/01　橋本満

## 検証したこと

`SELECT events.name, events.start_at, users.name,event_attendance.status FROM events LEFT JOIN event_attendance ON event_attendance.event_id = events.id LEFT JOIN users ON event_attendance.user_id = users.id WHERE events.start_at >= CURDATE() AND event_attendance.status='presence' ORDER BY events.name DESC;`

とターミナルに入力すると、

- [x] 処理日以降に開催されるイベントの参加答者一覧を出力することができる

- [x] イベントでソートされてる


## エビデンス

### ⏬ 処理日以降に開催される全てのイベント（参加するイベントのみ）

参加の場合は event_attendanceテーブルのstatusを 'presence' にしている。
下記の画像と比較すると、statusがpresence（参加）となっているもののみ取得できている。
また、イベントごとにソートもされている。

<img width="562" alt="スクリーンショット 2022-09-08 19 17 57" src="https://user-images.githubusercontent.com/86845003/189097932-57c13423-0c82-4599-a402-ddf0c4aba707.png">

### ⏬ 処理日以降に開催される全てのイベント（不参加・未回答も含む）

<img width="573" alt="スクリーンショット 2022-09-08 19 18 14" src="https://user-images.githubusercontent.com/86845003/189097944-391358db-dcb8-459a-bfd4-bacc53b45da1.png">
