### PR TITLE
#38 イベントの3日前にメールで通知する（通知する先は未回答となっている人のみ）

### DIFF
--- a/src/remind_mail_3_not_submitted.php
+++ b/src/remind_mail_3_not_submitted.php
@@ -11,7 +11,7 @@ mb_internal_encoding('UTF-8');
 $tomorrow_start  = date('Y-m-d 00:00:00', strtotime("+3 day"));
 $tomorrow_end  = date('Y-m-d 23:59:59', strtotime("+3 day"));
 
-// ３日後中に行われるイベントのみを取得 同時にuserにおいて、未回答者のみ取得
+// SELECT events.name, events.start_at, users.name,event_attendance.status FROM events LEFT JOIN event_attendance ON event_attendance.event_id = events.id LEFT JOIN users ON event_attendance.user_id = users.id WHERE events.start_at >= CURDATE() AND event_attendance.status='presence' ORDER BY events.name DESC;
 $stmt = $db->prepare("SELECT *
     FROM events 
     CROSS JOIN users 

--- a/src/remind_mail_3_not_submitted.php
+++ b/src/remind_mail_3_not_submitted.php
@@ -8,8 +8,8 @@ mb_language('ja');
 mb_internal_encoding('UTF-8');
 
 // 明日の始まりと終わり
-$tomorrow_start  = date('Y-m-d 00:00:00', strtotime("+1 day"));
-$tomorrow_end  = date('Y-m-d 23:59:59', strtotime("+1 day"));
+$tomorrow_start  = date('Y-m-d 00:00:00', strtotime("+3 day"));
+$tomorrow_end  = date('Y-m-d 23:59:59', strtotime("+3 day"));
 
 // ３日後中に行われるイベントのみを取得 同時にuserにおいて、statusがpresence（参加）となってる人のみ取得
 $stmt = $db->prepare("SELECT * FROM events 
@@ -19,12 +19,15 @@ LEFT JOIN users
 ON event_attendance.user_id = users.id
 WHERE '$tomorrow_start' < events.start_at 
 AND events.start_at < '$tomorrow_end' 
-AND event_attendance.status = 'presence'
+AND event_attendance.status IS NULL
 ");
+
 $stmt->execute();
 $participants = $stmt->fetchAll();
 
 foreach ($participants as $participant) {
+
+    var_dump($participant);
 
     $to = $participant['email'];
     $user_name = $participant['name'];
@@ -33,7 +36,7 @@ foreach ($participants as $participant) {
 
     $tomorrow_event_name = $participant[1];
     $subject = <<<EOT
-            『${tomorrow_event_name}』リマインドメール（前日 @参加者）
+            『${tomorrow_event_name}』リマインドメール（３日前 @未回答者）
             EOT;
     $body = "本文";
     $headers = ["From" => "system@posse-ap.com", "Content-Type" => "text/plain; charset=UTF-8", "Content-Transfer-Encoding" => "8bit"];

--- a/src/remind_mail_3_not_submitted.php
+++ b/src/remind_mail_3_not_submitted.php
@@ -12,15 +12,18 @@ $tomorrow_start  = date('Y-m-d 00:00:00', strtotime("+3 day"));
 $tomorrow_end  = date('Y-m-d 23:59:59', strtotime("+3 day"));
 
 // ３日後中に行われるイベントのみを取得 同時にuserにおいて、statusがpresence（参加）となってる人のみ取得
-$stmt = $db->prepare("SELECT * FROM events 
-JOIN event_attendance 
-ON event_attendance.event_id = events.id 
-LEFT JOIN users 
-ON event_attendance.user_id = users.id
-WHERE '$tomorrow_start' < events.start_at 
-AND events.start_at < '$tomorrow_end' 
-AND event_attendance.status IS NULL
+$stmt = $db->prepare("SELECT events.id, events.name, events.start_at, users.name 
+FROM events 
+CROSS JOIN users 
+WHERE events.start_at >= CURDATE() 
+AND NOT EXISTS (
+     select * from event_attendance 
+    where event_attendance.user_id = users.id 
+    and event_attendance.event_id = events.id) 
+    ORDER BY 'event.name' ASC;
 ");
+
+
 
 $stmt->execute();
 $participants = $stmt->fetchAll();


### PR DESCRIPTION
## 関連イシュー
#38 

### 終了条件

- [x] バッチを実行すると処理日がイベントの3日前の場合メールを送付する
- [x] メールの宛先は未回答としている人のみ
- [x] メールにはイベント名、内容、開催日時、回答を促す内容を記載する

## 検証したこと

- [x] ターミナル上にて　`php remind_mail_3_not_submitted.php`（メール処理を記述しているファイル）

とコマンドを打つと、mailhogにメールが送信されること

- [x] メールの内容にイベント名、内容、開催日時、回答を促す内容が記載されていること

- [x] 開催日３日前のイベントにのみメールが送信されていること

- [x] 未回答者にのみメールが送信されていること

## エビデンス

⏬ ターミナルで `php remind_mail_3_not_submitted.php`のコマンドを打つとメールが送信される

<img width="412" alt="スクリーンショット 2022-09-08 20 58 58" src="https://user-images.githubusercontent.com/86845003/189116381-69abf065-c596-4b0d-a389-e909d2f0ce3d.png">

#### 【状況】

- ユーザー：全３人
- 3日後のイベント：「花火大会」と「夏祭り」の二つ
- 「夏祭り」は３人未回答、「花火大会」は2人未回答である場合


⏬ 「夏祭り」は３通、「花火大会」は２通のメール通知がきている

<img width="1512" alt="スクリーンショット 2022-09-08 21 04 32" src="https://user-images.githubusercontent.com/86845003/189117358-a3202868-7661-41bc-8d36-ace160f12cf7.png">

⏬  メールの内容を確認メールの内容を確認（イベント名、内容、開催日時、氏名、回答を促す内容を記載）

<img width="1017" alt="スクリーンショット 2022-09-08 21 10 04" src="https://user-images.githubusercontent.com/86845003/189118400-c74b93af-6cad-407f-9fa1-bad814bd8afb.png">