### PR TITLE
#36 SQLで未回答者一覧を出力する

### DIFF
--- a/src/remind_mail_3_not_submitted.php
+++ b/src/remind_mail_3_not_submitted.php
@@ -11,7 +11,7 @@ mb_internal_encoding('UTF-8');
 $tomorrow_start  = date('Y-m-d 00:00:00', strtotime("+3 day"));
 $tomorrow_end  = date('Y-m-d 23:59:59', strtotime("+3 day"));
 
-// SELECT events.name, events.start_at, users.name,event_attendance.status FROM events LEFT JOIN event_attendance ON event_attendance.event_id = events.id LEFT JOIN users ON event_attendance.user_id = users.id WHERE events.start_at >= CURDATE() AND event_attendance.status='presence' ORDER BY events.name DESC;
+//三日後に開催するイベントのみ取得 同時に未回答者のみ抽出
 $stmt = $db->prepare("SELECT *
     FROM events 
     CROSS JOIN users 


### PR DESCRIPTION
## 関連イシュー
#36 

### 終了条件

- [x] どのイベントに誰が未回答か確認できる
- [x] 1回のSQLで処理日以降に開催される全てのイベントの情報が取得できる

■出力のイメージ（SQL結果に以下の情報が含まれていればOKです。ヘッダー、フッター書式は特に問いません）
Aイベント　1999/01/01　信田健児
Aイベント　1999/01/01　小谷悠一
Bイベント　1999/01/01　信田健児
Bイベント　1999/01/01　小谷悠一

駄目な例
※イベントでソートされていないので、Bイベントの未回答が誰かの確認が大変
Aイベント　1999/01/01　信田健児
Bイベント　1999/01/01　信田健児
Aイベント　1999/01/01　小谷悠一
Bイベント　1999/01/01　小谷悠一

## 検証したこと

```
SELECT events.id, events.name, events.start_at, users.name FROM events CROSS JOIN users WHERE events.start_at >= CURDATE() AND NOT EXISTS(
select * from event_attendance where event_attendance.user_id = users.id and event_attendance.event_id = events.id) ORDER BY 'event.name' ASC;
```

とターミナルに入力すると、

- [x] 処理日以降に開催されるイベントの未回答者一覧を出力することができる

- [x] イベントでソートされてる

## エビデンス

### ⏬ このように回答者がいない場合

<img width="342" alt="スクリーンショット 2022-09-08 21 47 15" src="https://user-images.githubusercontent.com/86845003/189127110-32310f57-6719-4a90-85af-b777d50d63c7.png">

### ⏬  スペもく・横もく・遊びは全員分のレコード表示される（ユーザーは全３人）

<img width="682" alt="スクリーンショット 2022-09-08 21 48 11" src="https://user-images.githubusercontent.com/86845003/189127420-301d22e7-46cd-4b63-bdc5-07c45d7c2f88.png">

### ⏬ スペもく・遊びを１人が「参加」と回答した場合

<img width="341" alt="スクリーンショット 2022-09-08 21 47 45" src="https://user-images.githubusercontent.com/86845003/189127846-4bb8621a-8762-49ac-b7a4-7f63dceabe19.png">

### ⏬  スペもく・遊びは２人分のレコード表示される（ユーザーは全３人）、「横もく」は３レコードのままである

<img width="672" alt="スクリーンショット 2022-09-08 21 48 21" src="https://user-images.githubusercontent.com/86845003/189128356-0d323370-e0da-4275-8f4b-ccb61ef8480b.png">
