### PR TITLE
#39 未回答管理 Issue4 イベントの3日前にメールで通知する 通知する先は未回答となっている人のみ slack通知

### DIFF
--- a/src/remind_mail_3_not_submitted.php
+++ b/src/remind_mail_3_not_submitted.php
@@ -7,9 +7,9 @@ date_default_timezone_set('Asia/Tokyo');
 mb_language('ja');
 mb_internal_encoding('UTF-8');
 
-// 明日の始まりと終わり
-$tomorrow_start  = date('Y-m-d 00:00:00', strtotime("+3 day"));
-$tomorrow_end  = date('Y-m-d 23:59:59', strtotime("+3 day"));
+// 3日後の始まりと終わり
+$three_days_later_start  = date('Y-m-d 00:00:00', strtotime("+3 day"));
+$three_days_later_end  = date('Y-m-d 23:59:59', strtotime("+3 day"));
 
 // SELECT events.name, events.start_at, users.name,event_attendance.status FROM events LEFT JOIN event_attendance ON event_attendance.event_id = events.id LEFT JOIN users ON event_attendance.user_id = users.id WHERE events.start_at >= CURDATE() AND event_attendance.status='presence' ORDER BY events.name DESC;
 $stmt = $db->prepare("SELECT *
@@ -20,7 +20,7 @@ $stmt = $db->prepare("SELECT *
      select * from event_attendance 
     where event_attendance.user_id = users.id 
     and event_attendance.event_id = events.id) 
-    and '$tomorrow_start' < start_at AND start_at < '$tomorrow_end';
+    and '$three_days_later_start' < start_at AND start_at < '$three_days_later_end';
 ");
 
 $stmt->execute();

--- a/src/slack1.php
+++ b/src/slack1.php
@@ -1,10 +1,6 @@
 <?php 
 require('dbconnect.php');
 
-date_default_timezone_set('Asia/Tokyo');
-mb_language('ja');
-mb_internal_encoding('UTF-8');
-
 // 明日の始まりと終わり
 $tomorrow_start  = date('Y-m-d 00:00:00', strtotime("+1 day"));
 $tomorrow_end  = date('Y-m-d 23:59:59', strtotime("+1 day"));

--- a/src/slack3.php
+++ b/src/slack3.php
@@ -1,0 +1,97 @@
+<?php
+require('dbconnect.php');
+
+// 三日後の始まりと終わり
+$three_days_later_start  = date('Y-m-d 00:00:00', strtotime("+3 day"));
+$three_days_later_end  = date('Y-m-d 23:59:59', strtotime("+3 day"));
+
+// SELECT events.name, events.start_at, users.name,event_attendance.status FROM events LEFT JOIN event_attendance ON event_attendance.event_id = events.id LEFT JOIN users ON event_attendance.user_id = users.id WHERE events.start_at >= CURDATE() AND event_attendance.status='presence' ORDER BY events.name DESC;
+$stmt = $db->prepare("SELECT events.name, events.detail, events.start_at, events.end_at, users.slack_id
+    FROM events 
+    CROSS JOIN users 
+    WHERE events.start_at >= CURDATE() 
+    AND NOT EXISTS (
+     select * from event_attendance 
+    where event_attendance.user_id = users.id 
+    and event_attendance.event_id = events.id) 
+    and '$three_days_later_start' < start_at AND start_at < '$three_days_later_end'
+    and events.id = 19;
+");
+$stmt->execute();
+$event = $stmt->fetch();
+
+// 未登録者数取得
+$stmt = $db->prepare("SELECT events.name, events.detail, events.start_at, events.end_at, users.slack_id
+    FROM events 
+    CROSS JOIN users 
+    WHERE events.start_at >= CURDATE() 
+    AND NOT EXISTS (
+     select * from event_attendance 
+    where event_attendance.user_id = users.id 
+    and event_attendance.event_id = events.id) 
+    and '$three_days_later_start' < start_at AND start_at < '$three_days_later_end'
+    and events.id = 19;
+");
+$stmt->execute();
+$participants = $stmt->fetchAll();
+
+
+$name = $event['name'];
+$detail = $event['detail'];
+$start_at = $event['start_at'];
+$end_at = $event['end_at'];
+$slack_id = $event['slack_id'];
+
+
+$array = [];
+foreach ($participants as $participant) {
+  $array[] = $participant['slack_id'];
+}
+$mentions = implode("><@", $array);
+
+
+$name = $event['name'];
+$detail = $event['detail'];
+$start_at = $event['start_at'];
+$end_at = $event['end_at'];
+$slack_id = $event['slack_id'];
+
+$url = 'https://hooks.slack.com/services/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';
+$message = [
+  "channel" => "#notify",
+  "username" => "イベント通知管理ボット",
+  "text" => "
+    ------------------------------------------
+    イベント【3日前】です！入力してください！
+
+    ■ イベント名
+    $name
+
+    ■ 内容
+    $detail
+
+    ■ 開催日時
+    $start_at ~ $end_at
+    
+    ■ 未回答者
+    <@$mentions>
+    ------------------------------------------
+    ",
+];
+
+// 配列用意、ループで文字列結合（スペース入れながら）
+// そこで変数差し込む
+
+$ch = curl_init();
+$options = [
+  CURLOPT_URL => $url,
+  CURLOPT_RETURNTRANSFER => true,
+  CURLOPT_SSL_VERIFYPEER => false,
+  CURLOPT_POST => true,
+  CURLOPT_POSTFIELDS => http_build_query([
+    'payload' => json_encode($message)
+  ])
+];
+curl_setopt_array($ch, $options);
+curl_exec($ch);
+curl_close($ch);


### PR DESCRIPTION
## 関連イシュー
#39

### 終了条件

- [x] バッチを実行すると処理日がイベントの3日前の場合Slackで通知する
- [x] メッセージの宛先は未回答の人のみ、チャンネルはチームごとに用意するチャンネル
- [x] メッセージにはイベント名、内容、開催日時、回答を促す内容を記載する

## 検証したこと
- [x] 3日後のイベントの参加者数をテーブルにて確認
- [x] phpコンテナ内で `php slack3.php  ` を実行し、slackに通知が行っていることを確認
- [x] slackの通知の内容はイベント名、内容、開催日時、回答を促す内容が記載されていることを確認

## エビデンス
三日後のイベントの未登録者は三人（今9/8なので、9/11が明日扱い）
<img width="1065" alt="image" src="https://user-images.githubusercontent.com/86785032/189145757-439a9680-04fc-4ee4-854e-f07fb62220d1.png">
コンテナでバッチ実行
<img width="336" alt="image" src="https://user-images.githubusercontent.com/86785032/189145879-2b85dd5a-293c-4d30-9283-94ea437d9bb6.png">
イベント名、内容、開催日時、回答を促す内容が記載されている通知がSlack に送られる
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/86785032/189145995-06d73723-6709-4ac9-bde5-a356df27171b.png">

